### PR TITLE
Change ReadByOffChainAddr to take wire.Address

### DIFF
--- a/contacts/contactsyaml/cache.go
+++ b/contacts/contactsyaml/cache.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	pwire "perun.network/go-perun/wire"
 
 	"github.com/hyperledger-labs/perun-node"
 )
@@ -66,11 +67,14 @@ func (c *contactsCache) readByAlias(alias string) (_ perun.Peer, isPresent bool)
 }
 
 // ReadByOffChainAddr returns the peer corresponding to given off-chain address from the cache.
-func (c *contactsCache) ReadByOffChainAddr(offChainAddr string) (_ perun.Peer, isPresent bool) {
+func (c *contactsCache) ReadByOffChainAddr(offChainAddr pwire.Address) (_ perun.Peer, isPresent bool) {
+	if offChainAddr == nil {
+		return perun.Peer{}, false
+	}
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 	var alias string
-	alias, isPresent = c.aliasByAddr[offChainAddr]
+	alias, isPresent = c.aliasByAddr[offChainAddr.String()]
 	if !isPresent {
 		return perun.Peer{}, false
 	}

--- a/contacts/contactsyaml/provider_test.go
+++ b/contacts/contactsyaml/provider_test.go
@@ -136,13 +136,13 @@ func Test_YAML_ReadByOffChainAddr(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("happy", func(t *testing.T) {
-		gotPeer, isPresent := c.ReadByOffChainAddr(peer1.OffChainAddrString)
+		gotPeer, isPresent := c.ReadByOffChainAddr(peer1.OffChainAddr)
 		assert.True(t, isPresent)
 		assert.Equal(t, peer1, gotPeer)
 	})
 
 	t.Run("missing_peer", func(t *testing.T) {
-		_, isPresent := c.ReadByOffChainAddr(missingPeer.OffChainAddrString)
+		_, isPresent := c.ReadByOffChainAddr(missingPeer.OffChainAddr)
 		assert.False(t, isPresent)
 	})
 }

--- a/perun.go
+++ b/perun.go
@@ -49,7 +49,7 @@ type Peer struct {
 // ContactsReader represents a read only cached list of contacts.
 type ContactsReader interface {
 	ReadByAlias(alias string) (p Peer, contains bool)
-	ReadByOffChainAddr(offChainAddr string) (p Peer, contains bool)
+	ReadByOffChainAddr(offChainAddr pwire.Address) (p Peer, contains bool)
 }
 
 // Contacts represents a cached list of contacts backed by a storage. Read, Write and Delete methods act on the


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->

Previously it takes string. OffChainAddressString is only a convenience
field in peer for easy marshalling / unmarshalling. The external API
should just take Alias or OffChainAddress as wire.Address.
##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

<!-- Bug Fix -->
<!-- Improvement -->
Implementation Task

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->
Resolves #80

#### Testing
<!-- Tell us how you have tested the changes. -->

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

1. All existing tests should pass.
2. 
3.  

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
