### PR TITLE
Use random nonce when accepting the proposal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,5 @@ require (
 	google.golang.org/protobuf v1.24.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	gotest.tools v2.2.0+incompatible
-	perun.network/go-perun v0.4.1-0.20200910151003-4bede739a3e4
+	perun.network/go-perun v0.4.1-0.20200916124044-27be1b2016bd
 )

--- a/go.sum
+++ b/go.sum
@@ -613,4 +613,6 @@ perun.network/go-perun v0.4.1-0.20200908131214-cdcc1ad25825 h1:IfWJsEOtI620Ap3cx
 perun.network/go-perun v0.4.1-0.20200908131214-cdcc1ad25825/go.mod h1:xwFshtUdzOXqSntwRVhNZjvSWWSnnUMRzq9gyjBURKc=
 perun.network/go-perun v0.4.1-0.20200910151003-4bede739a3e4 h1:IG73lxaukWiuBonhKU9CyxCdpw7rvaQ8FGBDXesXzZQ=
 perun.network/go-perun v0.4.1-0.20200910151003-4bede739a3e4/go.mod h1:xwFshtUdzOXqSntwRVhNZjvSWWSnnUMRzq9gyjBURKc=
+perun.network/go-perun v0.4.1-0.20200916124044-27be1b2016bd h1:kQ9SXAbrUEzCA7flcJZOgiHNlDCIWLrwYLoY6DUF500=
+perun.network/go-perun v0.4.1-0.20200916124044-27be1b2016bd/go.mod h1:xwFshtUdzOXqSntwRVhNZjvSWWSnnUMRzq9gyjBURKc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/session/session.go
+++ b/session/session.go
@@ -374,6 +374,7 @@ func (s *session) HandleProposal(chProposal pclient.ChannelProposal, responder *
 
 	notif := chProposalNotif(parts, currency.ETH, chProposal.Proposal(), expiry)
 	entry := chProposalResponderEntry{
+		proposal:  chProposal,
 		notif:     notif,
 		responder: responder,
 	}
@@ -473,8 +474,9 @@ func (s *session) RespondChProposal(pctx context.Context, chProposalID string, a
 func (s *session) acceptChProposal(pctx context.Context, entry chProposalResponderEntry) (perun.ChInfo, error) {
 	ctx, cancel := context.WithTimeout(pctx, s.timeoutCfg.respChProposalAccept(entry.notif.ChallengeDurSecs))
 	defer cancel()
-	nonceShare := pclient.WithRandomNonce()
-	resp := s.chProposalResponders[""].proposal.Proposal().NewChannelProposalAcc(s.user.OffChainAddr, nonceShare)
+
+	proposal := entry.proposal.Proposal()
+	resp := proposal.NewChannelProposalAcc(s.user.OffChainAddr, pclient.WithRandomNonce())
 	pch, err := entry.responder.Accept(ctx, resp)
 	if err != nil {
 		s.Error("Accepting channel proposal", err)


### PR DESCRIPTION

#### Description
Feature to use shared nonce was added in go-perun in this [commit](https://github.com/hyperledger-labs/go-perun/commit/ba500c4ec66481043dfd0b89be170023ef7fa11a). But this was missing some changes, which were added later in this [commit](https://github.com/hyperledger-labs/go-perun/commit/27be1b2016bd19bda0b7e9d0ec42ef5df4f903ac). This PR will cover the second part which will set nonce-share when accepting a proposal 

##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->
Improvement

##### Relevant issue
Closes #101

#### Testing
All existing tests should pass

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
