### PR TITLE
Refactor test helpers & Add generate command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ build:
 	go build $(LDFLAGS) $(NODE_PKG)
 
 clean:
-	rm perunnode
+	rm -rf perunnode node.yaml alice bob

--- a/api/grpc/server_integ_test.go
+++ b/api/grpc/server_integ_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hyperledger-labs/perun-node"
 	"github.com/hyperledger-labs/perun-node/api/grpc"
 	"github.com/hyperledger-labs/perun-node/api/grpc/pb"
+	"github.com/hyperledger-labs/perun-node/blockchain/ethereum/ethereumtest"
 	"github.com/hyperledger-labs/perun-node/currency"
 	"github.com/hyperledger-labs/perun-node/node"
 	"github.com/hyperledger-labs/perun-node/session/sessiontest"
@@ -81,6 +82,9 @@ func StartServer(t *testing.T, nodeCfg perun.NodeConfig, grpcPort string) {
 }
 
 func Test_Integ_Role(t *testing.T) {
+	// Deploy contracts on blockchain.
+	ethereumtest.SetupContractsT(t, ethereumtest.ChainURL, ethereumtest.ChainTxTimeout)
+
 	// Run server in a go routine.
 	StartServer(t, nodeCfg, grpcPort)
 
@@ -121,10 +125,10 @@ func Test_Integ_Role(t *testing.T) {
 	var alicePeer, bobPeer *pb.Peer
 	var chID string
 	prng := rand.New(rand.NewSource(1729))
-	aliceCfg := sessiontest.NewConfig(t, prng)
-	bobCfg := sessiontest.NewConfig(t, prng)
-	aliceCfgFile := sessiontest.NewConfigFile(t, aliceCfg)
-	bobCfgFile := sessiontest.NewConfigFile(t, bobCfg)
+	aliceCfg := sessiontest.NewConfigT(t, prng)
+	bobCfg := sessiontest.NewConfigT(t, prng)
+	aliceCfgFile := sessiontest.NewConfigFileT(t, aliceCfg)
+	bobCfgFile := sessiontest.NewConfigFileT(t, bobCfg)
 	wg := &sync.WaitGroup{}
 
 	// Run OpenSession for Alice, Bob in top level test, because cleaup functions

--- a/blockchain/ethereum/ethereumtest/chain.go
+++ b/blockchain/ethereum/ethereumtest/chain.go
@@ -51,7 +51,7 @@ type ChainBackendSetup struct {
 // It also generates the given number of accounts and funds them each with 10 ether.
 // and returns a test ChainBackend using the given randomness.
 func NewChainBackendSetup(t *testing.T, rng *rand.Rand, numAccs uint) *ChainBackendSetup {
-	walletSetup := NewWalletSetup(t, rng, numAccs)
+	walletSetup := NewWalletSetupT(t, rng, numAccs)
 
 	cbEth := newSimContractBackend(t, walletSetup.Accs, walletSetup.Keystore)
 	cb := &internal.ChainBackend{Cb: &cbEth, TxTimeout: ChainTxTimeout}

--- a/blockchain/ethereum/internal/wallet_test.go
+++ b/blockchain/ethereum/internal/wallet_test.go
@@ -36,7 +36,7 @@ func Test_WalletBackend_Interface(t *testing.T) {
 func Test_WalletBackend_NewWallet(t *testing.T) {
 	rng := rand.New(rand.NewSource(1729))
 	wb := ethereumtest.NewTestWalletBackend()
-	setup := ethereumtest.NewWalletSetup(t, rng, 1)
+	setup := ethereumtest.NewWalletSetupT(t, rng, 1)
 
 	t.Run("happy", func(t *testing.T) {
 		w, err := wb.NewWallet(setup.KeystorePath, "")
@@ -58,7 +58,7 @@ func Test_WalletBackend_NewWallet(t *testing.T) {
 func Test_WalletBackend_NewAccount(t *testing.T) {
 	rng := rand.New(rand.NewSource(1729))
 	wb := ethereumtest.NewTestWalletBackend()
-	setup := ethereumtest.NewWalletSetup(t, rng, 1)
+	setup := ethereumtest.NewWalletSetupT(t, rng, 1)
 
 	t.Run("happy", func(t *testing.T) {
 		w, err := wb.UnlockAccount(setup.Wallet, setup.Accs[0].Address())

--- a/client/client_integ_test.go
+++ b/client/client_integ_test.go
@@ -50,11 +50,10 @@ import (
 
 func Test_Integ_NewEthereumPaymentClient(t *testing.T) {
 	prng := rand.New(rand.NewSource(1729))
-	wb, userCfg := sessiontest.NewUserConfig(t, prng, 0)
+	wb, userCfg := sessiontest.NewUserConfigT(t, prng, 0)
 	user, err := session.NewUnlockedUser(wb, userCfg)
 	require.NoError(t, err, "initializing user")
-	adjudicator, asset := ethereumtest.SetupContracts(t, user.OnChain,
-		ethereumtest.ChainURL, ethereumtest.OnChainTxTimeout)
+	adjudicator, asset := ethereumtest.SetupContractsT(t, ethereumtest.ChainURL, ethereumtest.OnChainTxTimeout)
 
 	cfg := client.Config{
 		Chain: client.ChainConfig{
@@ -141,7 +140,7 @@ func Test_Integ_NewEthereumPaymentClient(t *testing.T) {
 	t.Run("err_invalid_on_chain_password", func(t *testing.T) {
 		cfg.DatabaseDir = newDatabaseDir(t) // start with empty persistence dir each time.
 		invalidUser := user
-		ws := ethereumtest.NewWalletSetup(t, prng, 0)
+		ws := ethereumtest.NewWalletSetupT(t, prng, 0)
 		invalidUser.OnChain.Wallet = ws.Wallet
 		invalidUser.OnChain.Keystore = ws.KeystorePath
 		invalidUser.OnChain.Password = "invalid-password"
@@ -153,7 +152,7 @@ func Test_Integ_NewEthereumPaymentClient(t *testing.T) {
 	t.Run("err_invalid_off_chain_password", func(t *testing.T) {
 		cfg.DatabaseDir = newDatabaseDir(t) // start with empty persistence dir each time.
 		invalidUser := user
-		ws := ethereumtest.NewWalletSetup(t, prng, 0)
+		ws := ethereumtest.NewWalletSetupT(t, prng, 0)
 		invalidUser.OffChain.Wallet = ws.Wallet
 		invalidUser.OffChain.Keystore = ws.KeystorePath
 		invalidUser.OffChain.Password = "invalid-password"

--- a/cmd/perunnode/flags.go
+++ b/cmd/perunnode/flags.go
@@ -18,8 +18,19 @@ package main
 
 import "github.com/spf13/pflag"
 
+// areAllFlagsUnspecified returns true if any of the flags were unspecified
+// when invoking the command to which the passed flagset was attached to.
+func areAllFlagsUnspecified(fs *pflag.FlagSet, flags ...string) bool {
+	for i := range flags {
+		if fs.Changed(flags[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // areAllFlagsSpecified returns true if all of the flags were specified
-// invoking the command to which the passed flagset was attached to.
+// when invoking the command to which the passed flagset was attached to.
 func areAllFlagsSpecified(fs *pflag.FlagSet, flags ...string) bool {
 	for i := range flags {
 		if !fs.Changed(flags[i]) {

--- a/cmd/perunnode/generate.go
+++ b/cmd/perunnode/generate.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2020 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository at
+// https://github.com/hyperledger-labs/perun-node
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger-labs/perun-node"
+	"github.com/hyperledger-labs/perun-node/blockchain/ethereum/ethereumtest"
+	"github.com/hyperledger-labs/perun-node/contacts/contactstest"
+	"github.com/hyperledger-labs/perun-node/session"
+	"github.com/hyperledger-labs/perun-node/session/sessiontest"
+)
+
+const (
+	aliceAlias, bobAlias = "alice", "bob"
+	nodeConfigFile       = "node.yaml"
+	sessionConfigFile    = "session.yaml"
+	keystoreDir          = "keystore"
+	contactsFile         = "contacts.yaml"
+	databaseDir          = "database"
+
+	onlyNodeF    = "only-node"
+	onlySessionF = "only-session"
+
+	dirFileMode = os.FileMode(0o750) // file mode for creating the directories for alice and bob.
+)
+
+var (
+	nodeCfg = perun.NodeConfig{
+		LogFile:              "",
+		LogLevel:             "debug",
+		ChainURL:             "ws://127.0.0.1:8545",
+		CommTypes:            []string{"tcp"},
+		ContactTypes:         []string{"yaml"},
+		CurrencyInterpreters: []string{"ETH"},
+
+		ChainConnTimeout: 30 * time.Second,
+		OnChainTxTimeout: 10 * time.Second,
+		ResponseTimeout:  10 * time.Second,
+	}
+
+	generateCmd = &cobra.Command{
+		Use:   "generate",
+		Short: "Generate demo artifacts",
+		Long: `
+Generate demo artifacts for node and session configuration.
+
+- Node: node.yaml file.
+- Session: Two directories (alice and bob) each containing session.yaml file,
+  contacts.yaml file and keystore directory with keys corresponding to the
+  on-chain and off-chain accounts.
+
+Note:
+=====
+Use the below command to start a ganache cli node with accounts corresponding
+to the generated keys pre-funded with 100 ETH each.
+
+ganache-cli -b 1 \
+ --account="0x7d51a817ee07c3f28581c47a5072142193337fdca4d7911e58c5af2d03895d1a,\
+100000000000000000000" \
+ --account="0x6aeeb7f09e757baa9d3935a042c3d0d46a2eda19e9b676283dce4eaf32e29dc9,\
+100000000000000000000"
+`,
+
+		Run: generate,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(generateCmd)
+	defineGenerateCmdFlags()
+}
+
+func defineGenerateCmdFlags() {
+	generateCmd.Flags().Bool(onlyNodeF, false, "generate only node configuration artifacts.")
+	generateCmd.Flags().Bool(onlySessionF, false, "generate only session configuration artifacts for both alice & bob.")
+}
+
+func generate(cmd *cobra.Command, args []string) {
+	genNodeConfig, err := cmd.Flags().GetBool(onlyNodeF)
+	if err != nil {
+		panic("unknown flag " + onlyNodeF + "\n")
+	}
+
+	genSessionConfig, err := cmd.Flags().GetBool(onlySessionF)
+	if err != nil {
+		panic("unknown flag " + onlySessionF + "\n")
+	}
+
+	// Enable generation of both config when no flags are specified.
+	if areAllFlagsUnspecified(cmd.Flags(), onlyNodeF, onlySessionF) {
+		genNodeConfig = true
+		genSessionConfig = true
+	}
+
+	// Generate configuration artifacts.
+	if genNodeConfig {
+		if err = generateNodeConfig(); err != nil {
+			fmt.Printf("Error generating node configuration artifacts: %v\n", err)
+		} else {
+			fmt.Printf("Generated node configuration file: %s\n", nodeConfigFile)
+		}
+	}
+	if genSessionConfig {
+		if err = generateSessionConfig(); err != nil {
+			fmt.Printf("Error generating session configuration artifacts: %v\n", err)
+		} else {
+			fmt.Printf("Generated session configuration artifacts: %s, %s directories\n", aliceAlias, bobAlias)
+		}
+	}
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+// generateNodeConfig generates node configuration artifact (node.yaml) in the current directory.
+func generateNodeConfig() error {
+	// Check if file exists.
+	if _, err := os.Stat(nodeConfigFile); !os.IsNotExist(err) {
+		return errors.New("file exists - " + nodeConfigFile)
+	}
+	adjudicator, asset := ethereumtest.ContractAddrs()
+	nodeCfg.Adjudicator = adjudicator.String()
+	nodeCfg.Asset = asset.String()
+	// Create file in temp dir.
+	tempNodeConfigFile, err := sessiontest.NewConfigFile(nodeCfg)
+	if err != nil {
+		return err
+	}
+	// Move the file to current directory.
+	filesToMove := map[string]string{tempNodeConfigFile: filepath.Join(nodeConfigFile)}
+	return moveFiles(filesToMove)
+}
+
+// generateSessionConfig generates two sets of session configuration artifacts in two directories named alice and bob.
+// Each directory would have: session.yaml, contacts.yaml and keystore (containing 2 key files - on-chain & off-chain).
+// To use this configuration, start the node from same directory containing the session config artifacts directory and
+// pass the path "alice/session.yaml" and "bob/session.yaml" for alice and bob respectively.
+func generateSessionConfig() error {
+	if isPresent, dirName := isAnyDirPresent(aliceAlias, bobAlias); isPresent {
+		return errors.New("dir exists - " + dirName)
+	}
+	if err := makeDirs(aliceAlias, bobAlias); err != nil {
+		return err
+	}
+
+	// Generate session config, the seed 1729 generates two accounts which were funded when starting
+	// the ganache cli node with the command documented in help message.
+	prng := rand.New(rand.NewSource(1729))
+	aliceCfg, err := sessiontest.NewConfig(prng)
+	if err != nil {
+		return err
+	}
+	aliceCfg.User.Alias = aliceAlias
+	bobCfg, err := sessiontest.NewConfig(prng)
+	if err != nil {
+		return err
+	}
+	bobCfg.User.Alias = bobAlias
+
+	// Create Contacts file.
+	aliceContactsFile, err := contactstest.NewYAMLFile(peer(bobCfg.User))
+	if err != nil {
+		return err
+	}
+	bobContactsFile, err := contactstest.NewYAMLFile(peer(aliceCfg.User))
+	if err != nil {
+		return err
+	}
+
+	// Create session config file.
+	aliceCfgFile, err := sessiontest.NewConfigFile(updatedConfigCopy(aliceCfg))
+	if err != nil {
+		return err
+	}
+	bobCfgFile, err := sessiontest.NewConfigFile(updatedConfigCopy(bobCfg))
+	if err != nil {
+		return err
+	}
+
+	// Move the artifacts to currenct directory.
+	filesToMove := map[string]string{
+		aliceCfgFile:                             filepath.Join(aliceAlias, sessionConfigFile),
+		aliceContactsFile:                        filepath.Join(aliceAlias, contactsFile),
+		aliceCfg.DatabaseDir:                     filepath.Join(aliceAlias, databaseDir),
+		aliceCfg.User.OnChainWallet.KeystorePath: filepath.Join(aliceAlias, keystoreDir),
+
+		bobCfgFile:                             filepath.Join(bobAlias, sessionConfigFile),
+		bobCfg.DatabaseDir:                     filepath.Join(bobAlias, databaseDir),
+		bobContactsFile:                        filepath.Join(bobAlias, contactsFile),
+		bobCfg.User.OnChainWallet.KeystorePath: filepath.Join(bobAlias, keystoreDir),
+	}
+	return moveFiles(filesToMove)
+}
+
+func isAnyDirPresent(dirNames ...string) (bool, string) {
+	for i := range dirNames {
+		if _, err := os.Stat(dirNames[i]); !os.IsNotExist(err) {
+			return true, dirNames[i]
+		}
+	}
+	return false, ""
+}
+
+func makeDirs(dirNames ...string) error {
+	var err error
+	for i := range dirNames {
+		if err = os.Mkdir(dirNames[i], dirFileMode); err != nil {
+			return errors.New("creating dir - " + dirNames[i])
+		}
+	}
+	return nil
+}
+
+func peer(userCfg session.UserConfig) perun.Peer {
+	return perun.Peer{
+		Alias:              userCfg.Alias,
+		OffChainAddrString: userCfg.OffChainAddr,
+		CommAddr:           userCfg.CommAddr,
+		CommType:           userCfg.CommType,
+	}
+}
+
+func updatedConfigCopy(cfg session.Config) session.Config {
+	cfgCopy := cfg
+	cfgCopy.ContactsURL = filepath.Join(cfg.User.Alias, contactsFile)
+	cfgCopy.DatabaseDir = filepath.Join(cfg.User.Alias, databaseDir)
+	cfgCopy.User.OnChainWallet.KeystorePath = filepath.Join(cfg.User.Alias, keystoreDir)
+	cfgCopy.User.OffChainWallet.KeystorePath = filepath.Join(cfg.User.Alias, keystoreDir)
+	return cfgCopy
+}
+
+func moveFiles(srcDest map[string]string) error {
+	errs := []string{}
+	for src, dest := range srcDest {
+		if err := os.Rename(src, dest); err != nil {
+			errs = append(errs, fmt.Sprintf("%s to %s: %v", src, dest, err))
+		}
+	}
+	if len(errs) != 0 {
+		return fmt.Errorf("moving files: %v", errs)
+	}
+	return nil
+}

--- a/contacts/contactsyaml/provider_test.go
+++ b/contacts/contactsyaml/provider_test.go
@@ -80,7 +80,7 @@ func Test_Contacts_Interface(t *testing.T) {
 
 func Test_NewContactsFromYaml_ReadByAlias(t *testing.T) {
 	t.Run("happy", func(t *testing.T) {
-		contactsFile := contactstest.NewYAMLFile(t, peer1, peer2)
+		contactsFile := contactstest.NewYAMLFileT(t, peer1, peer2)
 
 		gotContacts, err := contactsyaml.New(contactsFile, walletBackend)
 
@@ -105,7 +105,7 @@ func Test_NewContactsFromYaml_ReadByAlias(t *testing.T) {
 	t.Run("invalid_offchain_addr", func(t *testing.T) {
 		peer1Copy := peer1
 		peer1Copy.OffChainAddrString = "invalid address"
-		contactsFile := contactstest.NewYAMLFile(t, peer1Copy, peer2)
+		contactsFile := contactstest.NewYAMLFileT(t, peer1Copy, peer2)
 
 		_, err := contactsyaml.New(contactsFile, walletBackend)
 		assert.Error(t, err)
@@ -147,7 +147,7 @@ Bob:
 
 // nolint:dupl  // False positive. ReadByAlias is diff from ReadByOffChainAddr.
 func Test_YAML_ReadByAlias(t *testing.T) {
-	contactsFile := contactstest.NewYAMLFile(t, peer1, peer2)
+	contactsFile := contactstest.NewYAMLFileT(t, peer1, peer2)
 	c, err := contactsyaml.New(contactsFile, walletBackend)
 	assert.NoError(t, err)
 
@@ -165,7 +165,7 @@ func Test_YAML_ReadByAlias(t *testing.T) {
 
 // nolint:dupl  // False positive. ReadByOffChainAddr is diff from ReadByAlias.
 func Test_YAML_ReadByOffChainAddr(t *testing.T) {
-	contactsFile := contactstest.NewYAMLFile(t, peer1, peer2)
+	contactsFile := contactstest.NewYAMLFileT(t, peer1, peer2)
 	c, err := contactsyaml.New(contactsFile, walletBackend)
 	assert.NoError(t, err)
 
@@ -182,7 +182,7 @@ func Test_YAML_ReadByOffChainAddr(t *testing.T) {
 }
 
 func Test_YAML_Write_Read(t *testing.T) {
-	contactsFile := contactstest.NewYAMLFile(t, peer1, peer2)
+	contactsFile := contactstest.NewYAMLFileT(t, peer1, peer2)
 	c, err := contactsyaml.New(contactsFile, walletBackend)
 	assert.NoError(t, err)
 
@@ -206,7 +206,7 @@ func Test_YAML_Write_Read(t *testing.T) {
 	})
 
 	t.Run("invalid_offchain_addr", func(t *testing.T) {
-		contactsFile := contactstest.NewYAMLFile(t, peer1, peer2)
+		contactsFile := contactstest.NewYAMLFileT(t, peer1, peer2)
 		c, err := contactsyaml.New(contactsFile, walletBackend)
 		assert.NoError(t, err)
 
@@ -219,7 +219,7 @@ func Test_YAML_Write_Read(t *testing.T) {
 }
 
 func Test_YAML_Delete_Read(t *testing.T) {
-	contactsFile := contactstest.NewYAMLFile(t, peer1, peer2)
+	contactsFile := contactstest.NewYAMLFileT(t, peer1, peer2)
 	c, err := contactsyaml.New(contactsFile, walletBackend)
 	assert.NoError(t, err)
 
@@ -239,8 +239,8 @@ func Test_YAML_Delete_Read(t *testing.T) {
 func Test_YAML_UpdateStorage(t *testing.T) {
 	t.Run("happy_empty_file", func(t *testing.T) {
 		// Setup: NewYAML with zero entries
-		emptyFile := contactstest.NewYAMLFile(t)
-		fileWithTwoPeers := contactstest.NewYAMLFile(t, peer1, peer2)
+		emptyFile := contactstest.NewYAMLFileT(t)
+		fileWithTwoPeers := contactstest.NewYAMLFileT(t, peer1, peer2)
 		c, err := contactsyaml.New(emptyFile, walletBackend)
 		assert.NoError(t, err)
 
@@ -254,8 +254,8 @@ func Test_YAML_UpdateStorage(t *testing.T) {
 	})
 
 	t.Run("happy_non_empty_file", func(t *testing.T) {
-		fileWithTwoPeers := contactstest.NewYAMLFile(t, peer1, peer2)
-		fileWithThreePeers := contactstest.NewYAMLFile(t, peer1, peer2, peer3)
+		fileWithTwoPeers := contactstest.NewYAMLFileT(t, peer1, peer2)
+		fileWithThreePeers := contactstest.NewYAMLFileT(t, peer1, peer2, peer3)
 		c, err := contactsyaml.New(fileWithTwoPeers, walletBackend)
 		assert.NoError(t, err)
 		assert.NoError(t, c.Write(peer3.Alias, peer3))
@@ -267,7 +267,7 @@ func Test_YAML_UpdateStorage(t *testing.T) {
 
 	t.Run("file_permission_error", func(t *testing.T) {
 		// Setup: Create a copy of contacts file with test data and add entry
-		contactsFile := contactstest.NewYAMLFile(t, peer1, peer2)
+		contactsFile := contactstest.NewYAMLFileT(t, peer1, peer2)
 		c, err := contactsyaml.New(contactsFile, walletBackend)
 		assert.NoError(t, err)
 		assert.NoError(t, c.Write(peer3.Alias, peer3))

--- a/node/node_integ_test.go
+++ b/node/node_integ_test.go
@@ -99,8 +99,8 @@ func Test_Integ_New(t *testing.T) {
 	prng := rand.New(rand.NewSource(1729))
 	t.Run("happy_OpenSession", func(t *testing.T) {
 		var err error
-		sessionCfg := sessiontest.NewConfig(t, prng)
-		sessionCfgFile := sessiontest.NewConfigFile(t, sessionCfg)
+		sessionCfg := sessiontest.NewConfigT(t, prng)
+		sessionCfgFile := sessiontest.NewConfigFileT(t, sessionCfg)
 		sessionID, err = n.OpenSession(sessionCfgFile)
 		require.NoError(t, err)
 		assert.NotZero(t, sessionID)
@@ -123,9 +123,9 @@ func Test_Integ_New(t *testing.T) {
 	// Simulate one error to fail session.New
 	// Complete test of session.New is done in the session package.
 	t.Run("err_OpenSession_init_error", func(t *testing.T) {
-		sessionCfg := sessiontest.NewConfig(t, prng)
+		sessionCfg := sessiontest.NewConfigT(t, prng)
 		sessionCfg.ChainURL = "invalid-url"
-		sessionCfgFile := sessiontest.NewConfigFile(t, sessionCfg)
+		sessionCfgFile := sessiontest.NewConfigFileT(t, sessionCfg)
 		_, err := n.OpenSession(sessionCfgFile)
 		require.Error(t, err)
 		t.Log(err)

--- a/session/role_integ_test.go
+++ b/session/role_integ_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/hyperledger-labs/perun-node"
 	"github.com/hyperledger-labs/perun-node/blockchain/ethereum"
+	"github.com/hyperledger-labs/perun-node/blockchain/ethereum/ethereumtest"
 	"github.com/hyperledger-labs/perun-node/currency"
 	"github.com/hyperledger-labs/perun-node/session"
 	"github.com/hyperledger-labs/perun-node/session/sessiontest"
@@ -49,13 +50,14 @@ func init() {
 
 // This test includes all methods on SessionAPI and ChAPI.
 func Test_Integ_Role(t *testing.T) {
-	prng := rand.New(rand.NewSource(1729))
+	// Deploy contracts.
+	ethereumtest.SetupContractsT(t, ethereumtest.ChainURL, ethereumtest.ChainTxTimeout)
 
 	aliceAlias, bobAlias := "alice", "bob"
 
-	// Start with empty contacts.
-	aliceCfg := sessiontest.NewConfig(t, prng)
-	bobCfg := sessiontest.NewConfig(t, prng)
+	prng := rand.New(rand.NewSource(1729))
+	aliceCfg := sessiontest.NewConfigT(t, prng)
+	bobCfg := sessiontest.NewConfigT(t, prng)
 
 	alice, err := session.New(aliceCfg)
 	require.NoErrorf(t, err, "initializing alice session")

--- a/session/session_integ_test.go
+++ b/session/session_integ_test.go
@@ -45,7 +45,7 @@ func Test_Integ_New(t *testing.T) {
 	peers := newPeers(t, prng, uint(2))
 
 	prng = rand.New(rand.NewSource(1729))
-	cfg := sessiontest.NewConfig(t, prng, peers...)
+	cfg := sessiontest.NewConfigT(t, prng, peers...)
 
 	t.Run("happy", func(t *testing.T) {
 		sess, err := session.New(cfg)
@@ -135,7 +135,7 @@ func Test_Integ_New(t *testing.T) {
 		}
 		cfgCopy := cfg
 		cfgCopy.DatabaseDir = newDatabaseDir(t)
-		cfgCopy.ContactsURL = contactstest.NewYAMLFile(t, ownPeer)
+		cfgCopy.ContactsURL = contactstest.NewYAMLFileT(t, ownPeer)
 		_, err := session.New(cfgCopy)
 		t.Log(err)
 		assert.Error(t, err)

--- a/session/user_test.go
+++ b/session/user_test.go
@@ -32,7 +32,7 @@ import (
 func Test_New_Happy(t *testing.T) {
 	rng := rand.New(rand.NewSource(1729))
 	cntParts := uint(4)
-	wb, userCfg := sessiontest.NewUserConfig(t, rng, cntParts)
+	wb, userCfg := sessiontest.NewUserConfigT(t, rng, cntParts)
 
 	t.Run("non_empty_parts", func(t *testing.T) {
 		userCfgCopy := userCfg
@@ -69,7 +69,7 @@ func compareUserWithCfg(t *testing.T, gotUser perun.User, userCfg session.UserCo
 func Test_New_Unhappy(t *testing.T) {
 	rng := rand.New(rand.NewSource(1729))
 	cntParts := uint(1)
-	wb, userCfg := sessiontest.NewUserConfig(t, rng, cntParts)
+	wb, userCfg := sessiontest.NewUserConfigT(t, rng, cntParts)
 
 	t.Run("invalid_parts_address", func(t *testing.T) {
 		userCfgCopy := userCfg


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->
    
- Refactor test helper functions, so that they can also be used in non
test files as well.

- Move deploy function outside of NewConfig. Because when NewConfig
function is used in generate command, only the contract addresses are
required and the contracts need not be deployed.

- Add a generate command to perunnode application, that can generate
config file for node and session (for 2 roles alice & bob). These files
are same as the ones used in tests. They can be used along with cli app
that will be added later.

##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

<!-- Bug Fix -->
<!-- Improvement -->
Implementation Task

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

Closes #98.

#### Testing
<!-- Tell us how you have tested the changes. -->

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

1. To build the binary, run `make` from the project root.
2. To generate the artifacts, run the command `./perunnode generate`.
3. To check if the missing artifacts are generated, delete `node.yaml` and run the command in step 2. `node.yaml` should be generated and an error message for session config should be printed.
4. Repeat step 4 by deleting `alice` and `bob` directories instead of `node.yaml` and see if error message for node config is printed and session artifacts are generated.
5. To check if the generated configuration files are usable:
    a. Start the ganache-cli node using below command:
```
ganache-cli -b 1 --account="0x1fedd636dbc7e8d41a0622a2040b86fea8842cef9d4aa4c582aad00465b7acff,100000000000000000000" --account="0xb0309c60b4622d3071fad3e16c2ce4d0b1e7758316c187754f4dd0cfb44ceb33,100000000000000000000
```

  b. In another terminal, from the root directory of the project, start the perunnode using below command (the generated file node config file at default location will be used if no flags are specified.)
```
./perunnode run
```

  c. Comment out line no 87 in api/grpc/server_integ_test.go containing this function call "StartServer()" and line numbers 125 to 129 (where alice and bob config files are generated using test helpers). After the commented out lines, add the below two lines:
```
	aliceCfgFile := "alice/session.yaml"
	bobCfgFile := "bob/session.yaml"
```
This will use the session config artifacts generated by the generate command. Paths are specified relate to the directory in which perunnode binary is started.

Save the file and run the test from root folder of the project using below command:
```
go test -tags=integration -count=1 -cover ./api/grpc -v
```

The test should complete without any errors by connecting the running perunnode instead of starting its own. In the terminal where perunnode was started, the logs would be printed at debug level. 

  d. Stop the perunnode and ganache-cli by pressing Ctrl+C and remove the unnecessary files using `make clean`.

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
