### PR TITLE
Add command get on-chain balance in perunnode-cli

### DIFF
--- a/app/payment/session.go
+++ b/app/payment/session.go
@@ -49,7 +49,7 @@ func init() {
 	ppayment.SetAppDef(emptyAddr) // dummy app def.
 }
 
-// OpenSession opens a session and interprts the restored channels as payment channels.
+// OpenSession opens a session and interprets the restored channels as payment channels.
 func OpenSession(n perun.NodeAPI, configFile string) (string, []PayChInfo, error) {
 	sessionID, restoredChsInfo, err := n.OpenSession(configFile)
 	return sessionID, toPayChsInfo(restoredChsInfo), err

--- a/cmd/perunnodecli/README.md
+++ b/cmd/perunnodecli/README.md
@@ -58,7 +58,41 @@ This will generate the following artifacts:
   contacts.yaml file and keystore directory with keys corresponding to the
   on-chain and off-chain accounts.
 
-4. Start the perunnode:
+
+4. Set the blockchain address. Besides of commands to use API of perunnode,
+   this application also has a few helper commands to directly interact with
+   blockchain that are organized as sub-commands of chain command. To use these
+   commands, you need to first set the address of the blockchain node:
+
+```
+chain set-blockchain-address ws://127.0.0.1:8545
+```
+
+5. Deploy perun contracts on the newly started `ganache-cli` node using the
+   chain command.
+
+```
+chain deploy-perun-contracts
+```
+
+6. Reading on-chain balance. For reading the on-chain balance, you need to
+   specify the address as a hex string with a prefix of '0x'. For convenience,
+   the on-chain addresses that were funded when starting the ganache-cli node as
+   described in step 1 are already added to autocomplete. However, this command
+   can also be used to read on-chain balance for other addresses.
+
+First address is that of alice and second is that of bob. This can be verified
+by looking at the `alice/session.yaml` and `bob/session.yaml` files.
+
+```
+chain get-on-chain-balance 0x8450c0055cB180C7C37A25866132A740b812937B
+chain get-on-chain-balance 0xc4bA4815c82727554e4c12A07a139b74c6742322
+```
+
+You can use these commands at any time before opening, while open or after
+closing a payment channel.
+
+7. Start the perunnode:
 
 ```
 ./perunnode run
@@ -243,7 +277,7 @@ Now the program will opt for non-collaborative close by registering the state
 on the blockchain, waiting for the challenge duration to expire and then
 withdrawing the funds.
 
-Even if Bob doesn't respond, alice's request will wait until response timeout
+Even if Bob doesn't respond, Alice's request will wait until response timeout
 expires (in this demo it is 10s) and then proceed with non-collaborative
 close. Bob's node on the other hand will receive a notification when the
 channel is finalized on the blockchain and funds will be withdrawn

--- a/cmd/perunnodecli/chain.go
+++ b/cmd/perunnodecli/chain.go
@@ -19,10 +19,16 @@ package main
 import (
 	"github.com/abiosoft/ishell"
 
+	"github.com/hyperledger-labs/perun-node/blockchain/ethereum"
 	"github.com/hyperledger-labs/perun-node/blockchain/ethereum/ethereumtest"
+	"github.com/hyperledger-labs/perun-node/currency"
 )
 
 var (
+	aliceOnChainAddr = "0x8450c0055cB180C7C37A25866132A740b812937B"
+	bobOnChainAddr   = "0xc4bA4815c82727554e4c12A07a139b74c6742322"
+	chainAddr        string
+
 	chainCmdUsage = "Usage: chain [sub-command]"
 	chainCmd      = &ishell.Cmd{
 		Name: "chain",
@@ -30,36 +36,115 @@ var (
 		Func: chainFn,
 	}
 
+	setChainAddrCmdUsage = "Usage: set-blockchain-address [address]."
+	setChainAddrCmd      = &ishell.Cmd{
+		Name: "set-blockchain-address",
+		Help: "Set address of the blockchain node for reading balance." + setChainAddrCmdUsage,
+		Completer: func([]string) []string {
+			return []string{"ws://127.0.0.1:8545"} // Provide default values as autocompletion.
+		},
+		Func: setChainAddrFn,
+	}
+
+	getChainAddrCmdUsage = "Usage: get-blockchain-address."
+	getChainAddrCmd      = &ishell.Cmd{
+		Name: "get-blockchain-address",
+		Help: "Get address of the blockchain node for reading balance." + getChainAddrCmdUsage,
+		Func: getChainAddrFn,
+	}
+
 	deployPerunContractsCmdUsage = "Usage: deploy-perun-contracts."
 	deployPerunContractsCmd      = &ishell.Cmd{
 		Name: "deploy-perun-contracts",
 		Help: "Deploy perun smart contracts." + deployPerunContractsCmdUsage,
-		Completer: func([]string) []string {
-			return []string{"ws://127.0.0.1:8545"} // Provide default values as autocompletion.
-		},
 		Func: deployPerunContractsFn,
+	}
+
+	getOnChainBalanceCmdUsage = "Usage: deploy-perun-contracts."
+	getOnChainBalanceCmd      = &ishell.Cmd{
+		Name: "get-on-chain-balance",
+		Help: "Get on-chain balance." + getOnChainBalanceCmdUsage,
+		Completer: func([]string) []string {
+			return []string{aliceOnChainAddr, bobOnChainAddr}
+		},
+		Func: getOnChainBalanceFn,
 	}
 )
 
 func init() {
+	chainCmd.AddCmd(setChainAddrCmd)
+	chainCmd.AddCmd(getChainAddrCmd)
 	chainCmd.AddCmd(deployPerunContractsCmd)
+	chainCmd.AddCmd(getOnChainBalanceCmd)
 }
 
 func chainFn(c *ishell.Context) {
 	c.Println(c.Cmd.HelpText())
 }
 
-func deployPerunContractsFn(c *ishell.Context) {
+func setChainAddrFn(c *ishell.Context) {
 	countReqArgs := 1
 	if len(c.Args) != countReqArgs {
 		printArgCountError(c, countReqArgs)
 		return
 	}
+	chainAddr = c.Args[0]
 
-	adjudicator, asset, err := ethereumtest.SetupContracts(c.Args[0], ethereumtest.OnChainTxTimeout)
+	c.Printf("%s\n\n", greenf("Blockchain node address: %s\n", chainAddr))
+}
+
+func getChainAddrFn(c *ishell.Context) {
+	countReqArgs := 0
+	if len(c.Args) != countReqArgs {
+		printArgCountError(c, countReqArgs)
+		return
+	}
+
+	c.Printf("%s\n\n", greenf("Blockchain node address: %s\n", chainAddr))
+}
+
+func deployPerunContractsFn(c *ishell.Context) {
+	countReqArgs := 0
+	if len(c.Args) != countReqArgs {
+		printArgCountError(c, countReqArgs)
+		return
+	}
+	if chainAddr == "" {
+		c.Printf("%s\n\n", redf("Chain address is not set, set using below command %s", setChainAddrCmdUsage))
+		return
+	}
+
+	adjudicator, asset, err := ethereumtest.SetupContracts(chainAddr, ethereumtest.OnChainTxTimeout)
 	if err != nil {
 		c.Printf("%s\n\n", redf("Error deploying contracts: %v", err))
+		return
 	}
 	c.Printf("%s\n\n", greenf("Contracts deployed successfully.\nAdjudicator address: %v\nAsset address: %v\n",
 		adjudicator, asset))
+}
+
+func getOnChainBalanceFn(c *ishell.Context) {
+	countReqArgs := 1
+	if len(c.Args) != countReqArgs {
+		printArgCountError(c, countReqArgs)
+		return
+	}
+	if chainAddr == "" {
+		c.Printf("%s\n\n", redf("Chain address is not set, set using below command %s", setChainAddrCmdUsage))
+		return
+	}
+
+	addr, err := ethereum.NewWalletBackend().ParseAddr(c.Args[0])
+	if err != nil {
+		c.Printf("%s\n\n", redf("Error parsing address: %v", err))
+		return
+	}
+
+	bal, err := ethereum.BalanceAt(chainAddr, ethereumtest.ChainTxTimeout, ethereumtest.OnChainTxTimeout, addr)
+	if err != nil {
+		c.Printf("%s\n\n", redf("Error connecting to blockchain node: %v", err))
+		return
+	}
+
+	c.Printf("%s\n\n", greenf("On-chain balance: %s", currency.NewParser(currency.ETH).Print(bal)))
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->

The existing ChainBackend implementation in blockchain/ethereum
package currently uses ContractBackend interface defined in go-perun for
interacting with blockchain. This interface does not include a BalanceAt
method. Hence created an ephemeral connection to blockchain node for
reading on-chain address.

##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

<!-- Bug Fix -->
<!-- Improvement -->
Implementation Task

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

Closes #103.

#### Testing
<!-- Tell us how you have tested the changes. -->

Added commands to read on-chain balance. Steps to test this are added in `cmd/perunnodecli/Readme.md` in the Pr-requisites section. Steps 4 to 6. 

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
