### PR TITLE
Fix error in setting on-chain tx timeout

### DIFF
--- a/blockchain/ethereum/chain.go
+++ b/blockchain/ethereum/chain.go
@@ -62,7 +62,7 @@ func NewChainBackend(url string, chainConnTimeout, onChainTxTimeout time.Duratio
 	}
 	tr := pkeystore.NewTransactor(*ksWallet)
 	cb := pethchannel.NewContractBackend(ethereumBackend, tr)
-	return &internal.ChainBackend{Cb: &cb, TxTimeout: chainConnTimeout}, nil
+	return &internal.ChainBackend{Cb: &cb, TxTimeout: onChainTxTimeout}, nil
 }
 
 // BalanceAt reads the on-chain balance of the given address.

--- a/client/client_integ_test.go
+++ b/client/client_integ_test.go
@@ -58,10 +58,11 @@ func Test_Integ_NewEthereumPaymentClient(t *testing.T) {
 
 	cfg := client.Config{
 		Chain: client.ChainConfig{
-			Adjudicator: adjudicator.String(),
-			Asset:       asset.String(),
-			URL:         ethereumtest.ChainURL,
-			ConnTimeout: 10 * time.Second,
+			Adjudicator:      adjudicator.String(),
+			Asset:            asset.String(),
+			URL:              ethereumtest.ChainURL,
+			OnChainTxTimeout: ethereumtest.OnChainTxTimeout,
+			ConnTimeout:      10 * time.Second,
 		},
 		PeerReconnTimeout: 20 * time.Second,
 	}
@@ -70,7 +71,7 @@ func Test_Integ_NewEthereumPaymentClient(t *testing.T) {
 	t.Run("happy", func(t *testing.T) {
 		cfg.DatabaseDir = newDatabaseDir(t) // start with empty persistence dir each time.
 		client, err := client.NewEthereumPaymentClient(cfg, user, tcp.NewTCPBackend(5*time.Second))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = client.RestoreChs(func(*pclient.Channel) {})
 		assert.NoError(t, err)
 		assert.NoError(t, client.Close())


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->

There was an error in setting the on-chain transaction timeout in the `ethereum.NewChainBackend` function.
Because of the error, the instead of the transaction timeout value passed as an argument to the `NewChainBackend` API,
chain connection timeout was set as the on-chain transaction timeout in the backend.

This PR fixes that error. 

##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

Bug Fix
<!-- Improvement -->
<!-- Implementation Task -->

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21
Relates to #130.
We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

#### Testing
<!-- Tell us how you have tested the changes. -->
 
##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

1. All the existing tests pass. 
2.  If the on-chain tx timeout is changed in any of the test configs. For eg: in session config used in `Test_Integ_Role` in `session` package, then this is reflected when initializing the ChainBackend. Previously it was not reflected. 

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
