### PR TITLE
Update CI config to include integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,14 @@
 version: 2.1
 
 executors:
-  dst-go-executor:
+  perun-node-executor:
     docker:
-      - image: cimg/go:1.14.1
+      - image: cimg/go:1.14.1-node
     environment:
       RESULTS: /tmp/results
       ARTIFACTS: /tmp/artifacts
       TERM: xterm
-    working_directory: ~/dst-go
+    working_directory: ~/perun-node
 
 commands:
   checkout-code:
@@ -30,6 +30,20 @@ commands:
       - store_artifacts:
           path: /tmp/artifacts
 
+  install-ganache-cli:
+      steps:
+        - run: sudo npm install -g ganache-cli
+
+  run-ganache-cli:
+      steps:
+        - run:
+            command: ganache-cli -b 1 --account="0x1fedd636dbc7e8d41a0622a2040b86fea8842cef9d4aa4c582aad00465b7acff,100000000000000000000" --account="0xb0309c60b4622d3071fad3e16c2ce4d0b1e7758316c187754f4dd0cfb44ceb33,100000000000000000000"
+            background: true
+
+  wait-until-ganache-cli-is-running:
+      steps:
+        - run: timeout 15 bash -c 'until nc -z 127.0.0.1 8545; do sleep 1; done'
+
   install-txt-to-html-coverter-aha:
     steps:
       - run: sudo apt-get update
@@ -38,7 +52,7 @@ commands:
 jobs:
 
   lint:
-    executor: dst-go-executor
+    executor: perun-node-executor
     steps:
       - checkout-code
       - make-results-artifacts-dir
@@ -56,23 +70,37 @@ jobs:
       - upload-results-artifacts
 
 
-  unit_test:
-    executor: dst-go-executor
+  test:
+    executor: perun-node-executor
     steps:
       - checkout-code
       - make-results-artifacts-dir
+      - install-ganache-cli
+      - run-ganache-cli
+      - wait-until-ganache-cli-is-running
+      - run: echo "ganache-cli-running"
       - run:
-          name: Run unit tests
-          command: gotestsum --junitfile ${RESULTS}/unit-tests.xml --format=short-verbose -- -coverprofile=c.out ./...
+          name: Run unit and integration tests
+          command: gotestsum --junitfile ${RESULTS}/unit_and_integration_tests.xml --format=short-verbose -- -tags=integration -coverprofile=unit_and_integration_tests.out -p 1 ./...
+      # Run unit tests alone when the combined run of unit and integration tests fail.
       - run:
-          name: Generate coverage report
-          command: go tool cover -html=c.out -o ${ARTIFACTS}/unit_test_coverage.html
+          name: Run only unit tests
+          command: gotestsum --junitfile ${RESULTS}/unit_tests.xml --format=short-verbose -- -coverprofile=unit_tests.out ./...
+          when: on_fail
+      - run:
+          name: Generate coverage report for unit and integration tests.
+          command: go tool cover -html=unit_and_integration_tests.out -o ${ARTIFACTS}/unit_and_integration_tests.html
           when: always
+      # Only unit tests are run when the combined run of unit and integration tests fail. Only then the required artifacts for these coverage files are generated.
+      # So use on_fail condition.
+      - run:
+          name: Generate coverage report for only unit tests
+          command: go tool cover -html=unit_tests.out -o ${ARTIFACTS}/unit_test_coverage.html
+          when: on_fail
       - upload-results-artifacts
 
-
 workflows:
-  build-lint-test:
+  lint-test:
     jobs:
       - lint
-      - unit_test
+      - test


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->

- Update image to the variant that includes nodejs installed and run
ganache-cli node as background job for use by integration tests.

- Test job is configure such that, first all (integration and unit)
tests are run. Only if this fails, unit tests alone are run.

- Also update executor name from dst-go to perun-node.

##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

<!-- Bug Fix -->
<!-- Improvement -->
Implementation Task

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

Closes #60

#### Testing
<!-- Tell us how you have tested the changes. -->

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

1. Integration tests are run in the pipeline. 
2. To check if unit tests alone are run if the combined run of integration and unit tests fail, comment out the lines start ganache-cli node (78-80) in `.circleci/config.yml`. Such a run has also been done in my fork of the repo [here](https://app.circleci.com/pipelines/github/manoranjith/dst-go/162/workflows/4785ac52-5d80-43a9-a734-f6c48d9cad2e/jobs/335/artifacts).

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
