### PR TITLE
Fix channel watcher is started twice

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -160,7 +160,12 @@ func (c *client) RestoreChs(handler func(perun.Channel)) error {
 	c.EnablePersistence(pr)
 	ctx, cancel := context.WithTimeout(context.Background(), c.reconnTimeout)
 	defer cancel()
-	return c.Restore(ctx)
+	err = c.Restore(ctx)
+	// Set the OnNewChannel call back to a dummy function, so it does not
+	// process the channels that are created as a result of `ProposeChannel` or
+	// `Accept` on a channel proposal.
+	c.OnNewChannel(func(perun.Channel) {})
+	return err
 }
 
 // Close closes the client and waits until the listener and handler go routines return. It then closes the


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->

Fixes #154 by setting the `OnNewChannel` callback to a dummy function after the channels are restored. As a result, the channel created as a result of `ProposeChannel` and `Accept` methods are not processed by this callback.

##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

Bug Fix
<!-- Improvement -->
<!-- Implementation Task -->

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

Fixes #154.

#### Testing
<!-- Tell us how you have tested the changes. -->

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

1. Now `watcher` is returned only once.
2. 
3.  

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
