### PR TITLE
Fix occasional failure in session.Test_Integ_Role

### DIFF
--- a/session/channelRegistry.go
+++ b/session/channelRegistry.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2021 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository at
+// https://github.com/hyperledger-labs/perun-node
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session
+
+type (
+	// chRegistery stores a list of channels indexed by the channel ID.
+	// It preserves the order in which the channels are added.
+	chRegistry struct {
+		chIdxs map[string]int
+		chs    []*Channel
+	}
+)
+
+// newChRegistry initializes and returns a new channel registry.
+//
+// The registry is initialized to hold the passed number of channels. If more
+// channels are added, the size will automatically be increased.
+func newChRegistry(initialChRegistrySize uint16) *chRegistry {
+	return &chRegistry{
+		chIdxs: make(map[string]int),
+		chs:    make([]*Channel, 0, initialChRegistrySize),
+	}
+}
+
+// put adds the channel to the channel registry.
+//
+// If a channel with the same channel ID already exists, the new channel
+// replaces it. This however, should not occur, as the channel ID is expected to be unique.
+func (r *chRegistry) put(ch *Channel) {
+	r.chs = append(r.chs, ch)
+	r.chIdxs[ch.id] = len(r.chs) - 1
+}
+
+// get returns the channel corresponding to the passed channel ID.
+// If not channel is found, it returns nil.
+func (r *chRegistry) get(chID string) *Channel {
+	chIdx, ok := r.chIdxs[chID]
+	if !ok {
+		return nil
+	}
+	return r.chs[chIdx]
+}
+
+// count returns the count of channels in the registry.
+func (r *chRegistry) count() int { return len(r.chs) }
+
+// forEach runs the passed function on each of the channels in the registry.
+func (r *chRegistry) forEach(f func(i int, ch *Channel)) {
+	for i, ch := range r.chs {
+		f(i, ch)
+	}
+}

--- a/session/export_test.go
+++ b/session/export_test.go
@@ -63,7 +63,7 @@ func NewSessionForTest(cfg Config, isOpen bool, chClient perun.ChClient) (*Sessi
 		chAsset:              chAsset,
 		chClient:             chClient,
 		idProvider:           idProvider,
-		chs:                  make(map[string]*Channel),
+		chs:                  newChRegistry(initialChRegistrySize),
 		chProposalResponders: make(map[string]chProposalResponderEntry),
 	}, nil
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->

- The test case  Session_Close_NoForce_Error and
  OpenCh_Sub_Unsub_ChProposal_Respond_Accept in the mentioned test
  failed occasionally because of mismatch in channel IDs.

- Cause: Assumption (made in the tests) that GetChsInfo returns the
  channels in the order in which they were created is not always true.
  Because, GetChsInfo previously ranged over a map, in which case the
  elements are returned in random order during each iteration.

- Fix: Update the implementation of session, so that GetChsInfo returns
  the channels in the order in which they were created. Add a test case
  to document this behavior.

- Now, the assumption made in the test will always hold true (added a test case for this).

##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

Bug Fix
<!-- Improvement -->
<!-- Implementation Task -->

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

Fixes #179

#### Testing
<!-- Tell us how you have tested the changes. -->

Role integration test will be consistent. Will always pass (if implementation is correct) or always fail.

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->


1. Run the newly added test that ensures channels Info returned by `GetChsInfo` is always in the same order - order in which the channels were created.

```
# In session directory
go test -run Test_ProposeCh_GetChsInfo/Test_ProposeCh_GetChsInfo
```
2. Start ganache-cli node in a different terminal

```
ganache-cli -b 1 --account="0x1fedd636dbc7e8d41a0622a2040b86fea8842cef9d4aa4c582aad00465b7acff,100000000000000000000" --account="0xb0309c60b4622d3071fad3e16c2ce4d0b1e7758316c187754f4dd0cfb44ceb33,100000000000000000000"
``` 

3. Run the role integration test in session package (previously failing test).
```
# In session directory
go test -cover -p 1 -count=1 -tags=integration  -v -run Role 
```

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
