### PR TITLE
Improve API Error impl & document errors in API

### DIFF
--- a/api/grpc/server.go
+++ b/api/grpc/server.go
@@ -191,7 +191,7 @@ func (a *payChAPIServer) GetPeerID(ctx context.Context, req *pb.GetPeerIDReq) (*
 	}, nil
 }
 
-// OpenPayCh wraps session.OpenPayCh.
+// OpenPayCh wraps payment.OpenPayCh.
 func (a *payChAPIServer) OpenPayCh(ctx context.Context, req *pb.OpenPayChReq) (*pb.OpenPayChResp, error) {
 	errResponse := func(err perun.APIError) *pb.OpenPayChResp {
 		return &pb.OpenPayChResp{
@@ -224,7 +224,7 @@ func (a *payChAPIServer) OpenPayCh(ctx context.Context, req *pb.OpenPayChReq) (*
 	}, nil
 }
 
-// GetPayChsInfo wraps session.GetPayChs.
+// GetPayChsInfo wraps payment.GetPayChs.
 func (a *payChAPIServer) GetPayChsInfo(ctx context.Context, req *pb.GetPayChsInfoReq) (*pb.GetPayChsInfoResp, error) {
 	errResponse := func(err perun.APIError) *pb.GetPayChsInfoResp {
 		return &pb.GetPayChsInfoResp{
@@ -252,7 +252,7 @@ func (a *payChAPIServer) GetPayChsInfo(ctx context.Context, req *pb.GetPayChsInf
 	}, nil
 }
 
-// SubPayChProposals wraps session.SubPayChProposals.
+// SubPayChProposals wraps payment.SubPayChProposals.
 func (a *payChAPIServer) SubPayChProposals(req *pb.SubPayChProposalsReq,
 	srv pb.Payment_API_SubPayChProposalsServer) error {
 	sess, err := a.n.GetSession(req.SessionID)
@@ -290,7 +290,7 @@ func (a *payChAPIServer) SubPayChProposals(req *pb.SubPayChProposalsReq,
 	return nil
 }
 
-// UnsubPayChProposals wraps session.UnsubPayChProposals.
+// UnsubPayChProposals wraps payment.UnsubPayChProposals.
 func (a *payChAPIServer) UnsubPayChProposals(ctx context.Context, req *pb.UnsubPayChProposalsReq) (
 	*pb.UnsubPayChProposalsResp, error) {
 	errResponse := func(err perun.APIError) *pb.UnsubPayChProposalsResp {
@@ -329,7 +329,7 @@ func (a *payChAPIServer) closeGrpcPayChProposalSub(sessionID string) {
 	close(signal)
 }
 
-// RespondPayChProposal wraps session.RespondPayChProposal.
+// RespondPayChProposal wraps payment.RespondPayChProposal.
 func (a *payChAPIServer) RespondPayChProposal(ctx context.Context, req *pb.RespondPayChProposalReq) (
 	*pb.RespondPayChProposalResp, error) {
 	errResponse := func(err perun.APIError) *pb.RespondPayChProposalResp {
@@ -358,7 +358,7 @@ func (a *payChAPIServer) RespondPayChProposal(ctx context.Context, req *pb.Respo
 	}, nil
 }
 
-// CloseSession wraps session.CloseSession. For now, this is a stub.
+// CloseSession wraps payment.CloseSession. For now, this is a stub.
 func (a *payChAPIServer) CloseSession(ctx context.Context, req *pb.CloseSessionReq) (*pb.CloseSessionResp, error) {
 	errResponse := func(err perun.APIError) *pb.CloseSessionResp {
 		return &pb.CloseSessionResp{
@@ -386,7 +386,7 @@ func (a *payChAPIServer) CloseSession(ctx context.Context, req *pb.CloseSessionR
 	}, nil
 }
 
-// SendPayChUpdate wraps ch.SendPayChUpdate.
+// SendPayChUpdate wraps payment.SendPayChUpdate.
 func (a *payChAPIServer) SendPayChUpdate(ctx context.Context, req *pb.SendPayChUpdateReq) (
 	*pb.SendPayChUpdateResp, error) {
 	errResponse := func(err perun.APIError) *pb.SendPayChUpdateResp {
@@ -419,7 +419,7 @@ func (a *payChAPIServer) SendPayChUpdate(ctx context.Context, req *pb.SendPayChU
 	}, nil
 }
 
-// SubPayChUpdates wraps ch.SubPayChUpdates.
+// SubPayChUpdates wraps payment.SubPayChUpdates.
 func (a *payChAPIServer) SubPayChUpdates(req *pb.SubpayChUpdatesReq, srv pb.Payment_API_SubPayChUpdatesServer) error {
 	sess, err := a.n.GetSession(req.SessionID)
 	if err != nil {
@@ -479,7 +479,7 @@ var ToGrpcChUpdateType = map[perun.ChUpdateType]pb.SubPayChUpdatesResp_Notify_Ch
 	perun.ChUpdateTypeClosed: pb.SubPayChUpdatesResp_Notify_closed,
 }
 
-// UnsubPayChUpdates wraps ch.UnsubPayChUpdates.
+// UnsubPayChUpdates wraps payment.UnsubPayChUpdates.
 func (a *payChAPIServer) UnsubPayChUpdates(ctx context.Context, req *pb.UnsubPayChUpdatesReq) (
 	*pb.UnsubPayChUpdatesResp, error) {
 	errResponse := func(err perun.APIError) *pb.UnsubPayChUpdatesResp {
@@ -520,7 +520,7 @@ func (a *payChAPIServer) closeGrpcPayChUpdateSub(sessionID, chID string) {
 	close(signal)
 }
 
-// RespondPayChUpdate wraps ch.RespondPayChUpdate.
+// RespondPayChUpdate wraps payment.RespondPayChUpdate.
 func (a *payChAPIServer) RespondPayChUpdate(ctx context.Context, req *pb.RespondPayChUpdateReq) (
 	*pb.RespondPayChUpdateResp, error) {
 	errResponse := func(err perun.APIError) *pb.RespondPayChUpdateResp {
@@ -553,7 +553,7 @@ func (a *payChAPIServer) RespondPayChUpdate(ctx context.Context, req *pb.Respond
 	}, nil
 }
 
-// GetPayChInfo wraps ch.GetBalInfo.
+// GetPayChInfo wraps payment.GetBalInfo.
 func (a *payChAPIServer) GetPayChInfo(ctx context.Context, req *pb.GetPayChInfoReq) (
 	*pb.GetPayChInfoResp, error) {
 	errResponse := func(err perun.APIError) *pb.GetPayChInfoResp {
@@ -586,7 +586,7 @@ func (a *payChAPIServer) GetPayChInfo(ctx context.Context, req *pb.GetPayChInfoR
 	}, nil
 }
 
-// ClosePayCh wraps ch.ClosePayCh.
+// ClosePayCh wraps payment.ClosePayCh.
 func (a *payChAPIServer) ClosePayCh(ctx context.Context, req *pb.ClosePayChReq) (*pb.ClosePayChResp, error) {
 	errResponse := func(err perun.APIError) *pb.ClosePayChResp {
 		return &pb.ClosePayChResp{

--- a/app/payment/channel_test.go
+++ b/app/payment/channel_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/hyperledger-labs/perun-node/app/payment"
 	"github.com/hyperledger-labs/perun-node/currency"
 	"github.com/hyperledger-labs/perun-node/internal/mocks"
+	"github.com/hyperledger-labs/perun-node/peruntest"
+	"github.com/hyperledger-labs/perun-node/session"
 )
 
 func Test_SendPayChUpdate(t *testing.T) {
@@ -73,8 +75,8 @@ func Test_SendPayChUpdate(t *testing.T) {
 
 		invalidAmount := "abc"
 		_, gotErr := payment.SendPayChUpdate(context.Background(), chAPI, peerAlias, invalidAmount)
-		assertAPIError(t, gotErr, perun.ClientError, perun.ErrInvalidArgument, payment.ErrInvalidAmount.Error())
-		assertErrInfoInvalidArgument(t, gotErr.AddInfo(), "amount", invalidAmount)
+		peruntest.AssertAPIError(t, gotErr, perun.ClientError, perun.ErrInvalidArgument, payment.ErrInvalidAmount.Error())
+		peruntest.AssertErrInfoInvalidArgument(t, gotErr.AddInfo(), session.ArgNameAmount, invalidAmount)
 	})
 
 	t.Run("error_InvalidPayee", func(t *testing.T) {
@@ -83,8 +85,8 @@ func Test_SendPayChUpdate(t *testing.T) {
 
 		invalidPayee := "invalid-payee"
 		_, gotErr := payment.SendPayChUpdate(context.Background(), chAPI, invalidPayee, amountToSend)
-		assertAPIError(t, gotErr, perun.ClientError, perun.ErrInvalidArgument, payment.ErrInvalidPayee.Error())
-		assertErrInfoInvalidArgument(t, gotErr.AddInfo(), "payee", invalidPayee)
+		peruntest.AssertAPIError(t, gotErr, perun.ClientError, perun.ErrInvalidArgument, payment.ErrInvalidPayee.Error())
+		peruntest.AssertErrInfoInvalidArgument(t, gotErr.AddInfo(), "payee", invalidPayee)
 	})
 
 	t.Run("error_SendChUpdate", func(t *testing.T) {
@@ -245,22 +247,4 @@ func Test_ClosePayCh(t *testing.T) {
 		require.Error(t, gotErr)
 		t.Log(gotErr)
 	})
-}
-
-func assertAPIError(t *testing.T, e perun.APIError, category perun.ErrorCategory, code perun.ErrorCode, msg string) {
-	t.Helper()
-
-	assert.Equal(t, category, e.Category())
-	assert.Equal(t, code, e.Code())
-	assert.Contains(t, e.Message(), msg)
-}
-
-func assertErrInfoInvalidArgument(t *testing.T, info interface{}, name, value string) {
-	t.Helper()
-
-	addInfo, ok := info.(perun.ErrInfoInvalidArgument)
-	require.True(t, ok)
-	assert.Equal(t, name, addInfo.Name)
-	assert.Equal(t, value, addInfo.Value)
-	t.Log("requirement:", addInfo.Requirement)
 }

--- a/errors.go
+++ b/errors.go
@@ -18,30 +18,33 @@ package perun
 
 import (
 	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
 )
 
 // APIError represents the error that will be returned by the API of perun node.
+//
+// It implements Cause() and Unwrap() methods that implements the underlying
+// error, which can further be unwrapped, inspected.
+//
+// It also implements a customer Formatter, so that the stack trace of
+// underlying error is printed when using "%+v" verb.
 type apiError struct {
 	category ErrorCategory
 	code     ErrorCode
-	message  string
+	err      error
 	addInfo  interface{}
 }
 
 // Category returns the error category for this API Error.
-func (e apiError) Category() ErrorCategory {
-	return e.category
-}
+func (e apiError) Category() ErrorCategory { return e.category }
 
 // Code returns the error code for this API Error.
-func (e apiError) Code() ErrorCode {
-	return e.code
-}
+func (e apiError) Code() ErrorCode { return e.code }
 
 // Message returns the error message for this API Error.
-func (e apiError) Message() string {
-	return e.message
-}
+func (e apiError) Message() string { return e.err.Error() }
 
 // AddInfo returns the additional info for this API Error.
 func (e apiError) AddInfo() interface{} {
@@ -50,120 +53,183 @@ func (e apiError) AddInfo() interface{} {
 
 // Error implement the error interface for API error.
 func (e apiError) Error() string {
-	return fmt.Sprintf("Category: %s, Code: %d, Message: %s, AddInfo: %+v",
-		e.Category(), e.Code(), e.Message(), e.AddInfo())
+	return fmt.Sprintf("%s %d:%v", e.Category(), e.Code(), e.Message())
 }
+
+func (e apiError) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%s %d:%+v", e.Category(), e.Code(), e.err)
+			return
+		}
+		fallthrough
+	case 's':
+		//nolint: errcheck,gosec	// Error of ioString need not be checked.
+		io.WriteString(s, e.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", e.Error())
+	}
+}
+
+func (e apiError) Cause() error { return e.err }
+
+func (e apiError) Unwrap() error { return e.err }
 
 // NewAPIErr returns an APIErr with given parameters.
 //
 // For most use cases, call the error code specific constructor functions.
 // This function is intended for use in places only where an APIErr is to be modified.
+// For example, in app packages where the data in additional field is to be modified.
 // Copy each field, modify and create a new one using this function.
-func NewAPIErr(category ErrorCategory, code ErrorCode, message string, addInfo interface{}) APIError {
+func NewAPIErr(category ErrorCategory, code ErrorCode, err error, addInfo interface{}) APIError {
 	return apiError{
 		category: category,
 		code:     code,
-		message:  message,
+		err:      err,
 		addInfo:  addInfo,
 	}
 }
 
 // NewAPIErrPeerRequestTimedOut returns an ErrPeerRequestTimedOut API Error
 // with the given peer alias and response timeout.
-func NewAPIErrPeerRequestTimedOut(peerAlias, timeout, message string) APIError {
-	return apiError{
-		category: ParticipantError,
-		code:     ErrPeerRequestTimedOut,
-		message:  message,
-		addInfo: ErrInfoPeerRequestTimedOut{
+//
+// It does not validate the time string and it is in a proper format.  Eg: 10s.
+func NewAPIErrPeerRequestTimedOut(err error, peerAlias, timeout string) APIError {
+	message := fmt.Sprintf("timed out waiting for response from %s for %s", peerAlias, timeout)
+	return NewAPIErr(
+		ParticipantError,
+		ErrPeerRequestTimedOut,
+		errors.WithMessage(err, message),
+		ErrInfoPeerRequestTimedOut{
 			PeerAlias: peerAlias,
 			Timeout:   timeout,
 		},
-	}
+	)
 }
 
 // NewAPIErrPeerRejected returns an ErrPeerRejected API Error with the
 // given peer alias and reason.
-func NewAPIErrPeerRejected(peerAlias, reason, message string) APIError {
-	return apiError{
-		category: ParticipantError,
-		code:     ErrPeerRejected,
-		message:  message,
-		addInfo: ErrInfoPeerRejected{
+func NewAPIErrPeerRejected(err error, peerAlias, reason string) APIError {
+	message := fmt.Sprintf("peer %s rejected with reason %s", peerAlias, reason)
+	return NewAPIErr(
+		ParticipantError,
+		ErrPeerRejected,
+		errors.WithMessage(err, message),
+		ErrInfoPeerRejected{
 			PeerAlias: peerAlias,
 			Reason:    reason,
 		},
-	}
+	)
 }
 
 // NewAPIErrPeerNotFunded returns an ErrPeerNotFunded API Error with the
 // given peer alias.
-func NewAPIErrPeerNotFunded(peerAlias, message string) APIError {
-	return apiError{
-		category: ParticipantError,
-		code:     ErrPeerNotFunded,
-		message:  message,
-		addInfo: ErrInfoPeerNotFunded{
+func NewAPIErrPeerNotFunded(err error, peerAlias string) APIError {
+	message := fmt.Sprintf("peer %s did not fund within expected time", peerAlias)
+	return NewAPIErr(
+		ParticipantError,
+		ErrPeerNotFunded,
+		errors.WithMessage(err, message),
+		ErrInfoPeerNotFunded{
 			PeerAlias: peerAlias,
 		},
-	}
+	)
 }
 
 // NewAPIErrUserResponseTimedOut returns an ErrUserResponseTimedOut API Error
 // with the given expiry.
 func NewAPIErrUserResponseTimedOut(expiry, receivedAt int64) APIError {
-	return apiError{
-		category: ParticipantError,
-		code:     ErrUserResponseTimedOut,
-		message:  "user response timed out",
-		addInfo: ErrInfoUserResponseTimedOut{
+	message := fmt.Sprintf("response received (at %v) after timeout expired (at %v)", receivedAt, expiry)
+	return NewAPIErr(
+		ParticipantError,
+		ErrUserResponseTimedOut,
+		errors.New(message),
+		ErrInfoUserResponseTimedOut{
 			Expiry:     expiry,
 			ReceivedAt: receivedAt,
 		},
-	}
+	)
 }
 
+// ResourceType is used to enumerate valid resource types in ResourceNotFound
+// and ResourceExists errors.
+//
+// The enumeration of valid constants should be defined in the package using
+// the error constructors.
+type ResourceType string
+
 // NewAPIErrResourceNotFound returns an ErrResourceNotFound API Error with
-// the given resource type, ID and error message.
-func NewAPIErrResourceNotFound(resourceType, resourceID, message string) APIError {
-	return apiError{
-		category: ClientError,
-		code:     ErrResourceNotFound,
-		message:  message,
-		addInfo: ErrInfoResourceNotFound{
-			Type: resourceType,
+// the given resource type and ID.
+func NewAPIErrResourceNotFound(resourceType ResourceType, resourceID string) APIError {
+	message := fmt.Sprintf("cannot find %s with ID: %s", resourceType, resourceID)
+	return NewAPIErr(
+		ClientError,
+		ErrResourceNotFound,
+		errors.New(message),
+		ErrInfoResourceNotFound{
+			Type: string(resourceType),
 			ID:   resourceID,
 		},
-	}
+	)
 }
 
 // NewAPIErrResourceExists returns an ErrResourceExists API Error with
-// the given resource type, ID and error message.
-func NewAPIErrResourceExists(resourceType, resourceID, message string) APIError {
-	return apiError{
-		category: ClientError,
-		code:     ErrResourceExists,
-		message:  message,
-		addInfo: ErrInfoResourceExists{
-			Type: resourceType,
+// the given resource type and ID.
+func NewAPIErrResourceExists(resourceType ResourceType, resourceID string) APIError {
+	message := fmt.Sprintf("%s with ID: %s already exists", resourceType, resourceID)
+	return NewAPIErr(
+		ClientError,
+		ErrResourceExists,
+		errors.New(message),
+		ErrInfoResourceExists{
+			Type: string(resourceType),
 			ID:   resourceID,
 		},
-	}
+	)
 }
 
+// ArgumentName type is used enumerate valid argument names for use
+// InvalidArgument error.
+//
+// The enumeration of valid constants should be defined in the package using
+// the error constructors.
+type ArgumentName string
+
 // NewAPIErrInvalidArgument returns an ErrInvalidArgument API Error with the given
-// argument name, value, requirement for the argument and the error message.
-func NewAPIErrInvalidArgument(name, value, requirement, message string) APIError {
-	return apiError{
-		category: ClientError,
-		code:     ErrInvalidArgument,
-		message:  message,
-		addInfo: ErrInfoInvalidArgument{
-			Name:        name,
-			Value:       value,
-			Requirement: requirement,
+// argument name and value.
+func NewAPIErrInvalidArgument(err error, name ArgumentName, value string) APIError {
+	message := fmt.Sprintf("invalid value for %s: %s", name, value)
+	return NewAPIErr(
+		ClientError,
+		ErrInvalidArgument,
+		errors.WithMessage(err, message),
+		ErrInfoInvalidArgument{
+			Name:  string(name),
+			Value: value,
 		},
-	}
+	)
+}
+
+// NewAPIErrFailedPreCondition returns an ErrFailedPreCondition API Error with
+// the given error message.
+//
+// By default, the additional info for this type of err is nil. In case where
+// additional info is to be included (to be documented in the API),
+// constructors for APIErrFailedPreCondition specific to that case should be used.
+func NewAPIErrFailedPreCondition(err error) APIError {
+	return newAPIErrFailedPreCondition(err, nil)
+}
+
+// NewAPIErrFailedPreConditionUnclosedChs returns an ErrFailedPreCondition
+// API Error for the special case where channel close was closed with no-force
+// option and, one or more open channels exists.
+//
+func NewAPIErrFailedPreConditionUnclosedChs(err error, chs []ChInfo) APIError {
+	return newAPIErrFailedPreCondition(err,
+		ErrInfoFailedPreCondUnclosedChs{
+			ChInfos: chs,
+		})
 }
 
 // NewAPIErrFailedPreCondition returns an ErrFailedPreCondition API Error with the given
@@ -172,87 +238,92 @@ func NewAPIErrInvalidArgument(name, value, requirement, message string) APIError
 // AddInfo is taken as interface because for this error, the callers can
 // provide different type of additional info, as defined in the corresponding
 // APIs.
-func NewAPIErrFailedPreCondition(message string, addInfo interface{}) APIError {
-	return apiError{
-		category: ClientError,
-		code:     ErrFailedPreCondition,
-		message:  message,
-		addInfo:  addInfo,
-	}
+func newAPIErrFailedPreCondition(err error, addInfo interface{}) APIError {
+	message := "failed pre-condition"
+	return NewAPIErr(
+		ClientError,
+		ErrFailedPreCondition,
+		errors.WithMessage(err, message),
+		addInfo,
+	)
 }
 
-// NewAPIErrInvalidConfig returns an ErrInvalidConfig, API Error with the
-// given error message.
-func NewAPIErrInvalidConfig(name, value, message string) APIError {
-	return apiError{
-		category: ClientError,
-		code:     ErrInvalidConfig,
-		message:  message,
-		addInfo: ErrInfoInvalidConfig{
+// NewAPIErrInvalidConfig returns an ErrInvalidConfig, API Error with the given
+// config name and value.
+func NewAPIErrInvalidConfig(err error, name, value string) APIError {
+	message := fmt.Sprintf("invalid value for %s: %s", name, value)
+	return NewAPIErr(
+		ClientError,
+		ErrInvalidConfig,
+		errors.WithMessage(err, message),
+		ErrInfoInvalidConfig{
 			Name:  name,
 			Value: value,
 		},
-	}
-}
-
-// NewAPIErrInfoFailedPreConditionUnclosedChs returns additional info for a
-// specific case of ErrFailedPreCondition when Session.Close API is called
-// without force option and there are one or more unclosed channels in it.
-func NewAPIErrInfoFailedPreConditionUnclosedChs(chs []ChInfo) interface{} {
-	return ErrInfoFailedPreCondUnclosedChs{
-		ChInfos: chs,
-	}
+	)
 }
 
 // NewAPIErrInvalidContracts returns an ErrInvalidContracts API Error with the
-// given error message.
-func NewAPIErrInvalidContracts(contractsInfo []ContractErrInfo) APIError {
-	return apiError{
-		category: ClientError,
-		code:     ErrInvalidContracts,
-		message:  "error in contract validation",
-		addInfo: ErrInfoInvalidContracts{
-			ContractErrInfos: contractsInfo,
-		},
+// given contract error infos.
+//
+// For this error, stack traces of errors for each contract cannot be
+// retreived, as there are more than one.
+func NewAPIErrInvalidContracts(contractErrInfos []ContractErrInfo) APIError {
+	contractsErrInfosMsg := ""
+	for _, c := range contractErrInfos {
+		contractsErrInfosMsg += fmt.Sprintf("(%s at address %s: %v) ", c.Name, c.Address, c.Error)
 	}
+	message := "invalid contracts: " + contractsErrInfosMsg
+	return NewAPIErr(
+		ClientError,
+		ErrInvalidContracts,
+		errors.New(message),
+		ErrInfoInvalidContracts{
+			ContractErrInfos: contractErrInfos,
+		},
+	)
 }
 
 // NewAPIErrTxTimedOut returns an ErrTxTimedOut API Error with the given
 // error message.
-func NewAPIErrTxTimedOut(txType, txID, txTimeout, message string) APIError {
-	return apiError{
-		category: ProtocolFatalError,
-		code:     ErrTxTimedOut,
-		message:  message,
-		addInfo: ErrInfoTxTimedOut{
+func NewAPIErrTxTimedOut(err error, txType, txID, txTimeout string) APIError {
+	message := fmt.Sprintf("timed out waiting for %s tx (ID:%s) to be mined in %s: %v", txType, txID, txTimeout, err)
+	return NewAPIErr(
+		ProtocolFatalError,
+		ErrTxTimedOut,
+		errors.WithMessage(err, message),
+		ErrInfoTxTimedOut{
 			TxType:    txType,
 			TxID:      txID,
 			TxTimeout: txTimeout,
 		},
-	}
+	)
 }
 
 // NewAPIErrChainNotReachable returns an ErrChainNotReachable API Error
 // with the given error message.
-func NewAPIErrChainNotReachable(chainURL, message string) APIError {
-	return apiError{
-		category: ProtocolFatalError,
-		code:     ErrChainNotReachable,
-		message:  message,
-		addInfo: ErrInfoChainNotReachable{
+func NewAPIErrChainNotReachable(err error, chainURL string) APIError {
+	message := fmt.Sprintf("chain not reachable at URL %s", chainURL)
+	return NewAPIErr(
+		ProtocolFatalError,
+		ErrChainNotReachable,
+		errors.WithMessage(err, message),
+		ErrInfoChainNotReachable{
 			ChainURL: chainURL,
 		},
-	}
+	)
 }
 
 // NewAPIErrUnknownInternal returns an ErrUnknownInternal API Error with the given
 // error message.
 func NewAPIErrUnknownInternal(err error) APIError {
-	return apiError{
-		category: InternalError,
-		code:     ErrUnknownInternal,
-		message:  err.Error(),
-	}
+	message := "unknown internal error"
+	return NewAPIErr(
+		InternalError,
+		ErrUnknownInternal,
+		errors.WithMessage(err, message),
+		nil,
+	)
 }
 
 // APIErrAsMap returns a map containing entries for the method and each of
@@ -263,6 +334,5 @@ func APIErrAsMap(method string, err APIError) map[string]interface{} {
 		"method":   method,
 		"category": err.Category().String(),
 		"code":     err.Code(),
-		"add info": fmt.Sprintf("%+v", err.AddInfo()),
 	}
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -17,68 +17,256 @@
 package perun_test
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/perun-node"
+	"github.com/hyperledger-labs/perun-node/peruntest"
 )
 
-// nolint: dupl	// not duplicate of test Test_NewErrResourceExists.
-func Test_NewErrResourceNotFound(t *testing.T) {
-	resourceType := "any-type"
-	resourceID := "any-id"
-	message := "any-message"
+var errTest = fmt.Errorf("const error for test")
 
-	err := perun.NewAPIErrResourceNotFound(resourceType, resourceID, message)
-	require.NotNil(t, err)
+type customError1 struct{ actualErr error }
 
-	assert.Equal(t, perun.ClientError, err.Category())
-	assert.Equal(t, perun.ErrResourceNotFound, err.Code())
-	assert.Equal(t, message, err.Message())
-	addInfo, ok := err.AddInfo().(perun.ErrInfoResourceNotFound)
-	require.True(t, ok)
-	assert.Equal(t, addInfo.Type, resourceType)
-	assert.Equal(t, addInfo.ID, resourceID)
-	t.Log(err.Error())
+func (c customError1) Error() string { return "custom error 1: " + c.actualErr.Error() }
+func (c customError1) Unwrap() error { return c.actualErr }
+
+type customError2 struct{ actualErr error }
+
+func (c customError2) Error() string { return "custom error 2: " + c.actualErr.Error() }
+func (c customError2) Unwrap() error { return c.actualErr }
+
+type stackTracer interface {
+	StackTrace() errors.StackTrace
 }
 
-// nolint: dupl	// not duplicate of test Test_NewErrResourceNotFound.
-func Test_NewErrResourceExists(t *testing.T) {
-	resourceType := "any-type"
-	resourceID := "any-id"
-	message := "any-message"
+func Test_NewAPIErr(t *testing.T) {
+	// Construct an error that contain an underlying custom error and error constant.
+	// So that, they can be inspected using errors.(Is|As)
+	err := errors.WithStack(customError1{
+		actualErr: customError2{errTest},
+	})
 
-	err := perun.NewAPIErrResourceExists(resourceType, resourceID, message)
-	require.NotNil(t, err)
+	// Construct an APIError.
+	category := perun.InternalError
+	code := perun.ErrUnknownInternal
+	apiErr := perun.NewAPIErr(category, code, err, nil)
 
-	assert.Equal(t, perun.ClientError, err.Category())
-	assert.Equal(t, perun.ErrResourceExists, err.Code())
-	assert.Equal(t, message, err.Message())
-	addInfo, ok := err.AddInfo().(perun.ErrInfoResourceExists)
+	// Test if code, category and message are assigned properly.
+	peruntest.AssertAPIError(t, apiErr, category, code, err.Error())
+
+	// Test if message is formated properly when using error and fmt.Formatter interfaces.
+	wantErrMsg := "Internal 401:custom error 1: custom error 2: const error for test"
+	stackTrace, ok := err.(stackTracer)
 	require.True(t, ok)
-	assert.Equal(t, addInfo.Type, resourceType)
-	assert.Equal(t, addInfo.ID, resourceID)
-	t.Log(err.Error())
+
+	assert.Equal(t, wantErrMsg, apiErr.Error())
+	assert.Equal(t, wantErrMsg, fmt.Sprintf("%v", apiErr))
+	assert.Equal(t, fmt.Sprintf("%q", wantErrMsg), fmt.Sprintf("%q", apiErr))
+	assert.Contains(t, fmt.Sprintf("%+v", apiErr), fmt.Sprintf("%+v", stackTrace))
+
+	// Explicitly test Unwrap and Cause functions.
+	eCause := errors.Cause(apiErr)
+	require.EqualError(t, eCause, err.Error())
+	eUnwrap := errors.Unwrap(apiErr)
+	require.EqualError(t, eUnwrap, err.Error())
+
+	// Test if underlying errors can be retrieved.
+	e1 := customError1{}
+	ok = errors.As(err, &e1)
+	require.True(t, ok)
+
+	e2 := customError2{}
+	ok = errors.As(err, &e2)
+	require.True(t, ok)
+
+	ok = errors.Is(e2, errTest)
+	require.True(t, ok)
+}
+
+func Test_NewAPIErrPeerRequestTimedOut(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+	}{
+		{"valid_timeout", "1m0s"},
+		{"invalid_timeout", "invalid-duration-string"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := errors.New("sample error")
+			peerAlias := "some-alias"
+			timeout := tt.timeout
+			wantMsg := fmt.Sprintf("timed out waiting for response from %s for %s: %v", peerAlias, timeout, err)
+
+			apiErr := perun.NewAPIErrPeerRequestTimedOut(err, peerAlias, timeout)
+			peruntest.AssertAPIError(t, apiErr, perun.ParticipantError, perun.ErrPeerRequestTimedOut, wantMsg)
+			peruntest.AssertErrInfoPeerRequestTimedOut(t, apiErr.AddInfo(), peerAlias, timeout)
+		})
+	}
+}
+
+func Test_NewAPIErrPeerRejected(t *testing.T) {
+	err := errors.New("sample error")
+	peerAlias := "some-alias"
+	reason := "random reason"
+	wantMsg := fmt.Sprintf("peer %s rejected with reason %s: %v", peerAlias, reason, err)
+
+	apiErr := perun.NewAPIErrPeerRejected(err, peerAlias, reason)
+	peruntest.AssertAPIError(t, apiErr, perun.ParticipantError, perun.ErrPeerRejected, wantMsg)
+	peruntest.AssertErrInfoPeerRejected(t, apiErr.AddInfo(), peerAlias, reason)
+}
+
+func Test_NewAPIErrPeerNotFunded(t *testing.T) {
+	err := errors.New("sample error")
+	peerAlias := "some-alias"
+	wantMsg := fmt.Sprintf("peer %s did not fund within expected time: %v", peerAlias, err)
+
+	apiErr := perun.NewAPIErrPeerNotFunded(err, peerAlias)
+	peruntest.AssertAPIError(t, apiErr, perun.ParticipantError, perun.ErrPeerNotFunded, wantMsg)
+	peruntest.AssertErrInfoPeerNotFunded(t, apiErr.AddInfo(), peerAlias)
+}
+
+func Test_NewAPIErrUserResponseTimedOut(t *testing.T) {
+	expiry := time.Now().Unix()
+	receivedAt := time.Now().Add(1 * time.Second).Unix()
+	wantMsg := fmt.Sprintf("response received (at %v) after timeout expired (at %v)", receivedAt, expiry)
+
+	apiErr := perun.NewAPIErrUserResponseTimedOut(expiry, receivedAt)
+	peruntest.AssertAPIError(t, apiErr, perun.ParticipantError, perun.ErrUserResponseTimedOut, wantMsg)
+	// not using helper function, because it will only test
+	// if receivedAt is later than expiry and if expiry is in the past.
+	// here test only if proper values are assigned.
+	addInfo, ok := apiErr.AddInfo().(perun.ErrInfoUserResponseTimedOut)
+	require.True(t, ok)
+	assert.Equal(t, expiry, addInfo.Expiry)
+	assert.Equal(t, receivedAt, addInfo.ReceivedAt)
+}
+
+func Test_NewErrResourceNotFound(t *testing.T) {
+	resourceType := perun.ResourceType("any-type")
+	resourceID := "any-id"
+	wantMsg := fmt.Sprintf("cannot find %s with ID: %s", resourceType, resourceID)
+
+	apiErr := perun.NewAPIErrResourceNotFound(resourceType, resourceID)
+	peruntest.AssertAPIError(t, apiErr, perun.ClientError, perun.ErrResourceNotFound, wantMsg)
+	peruntest.AssertErrInfoResourceNotFound(t, apiErr.AddInfo(), resourceType, resourceID)
+}
+
+func Test_NewErrResourceExists(t *testing.T) {
+	resourceType := perun.ResourceType("any-type")
+	resourceID := "any-id"
+	wantMsg := fmt.Sprintf("%s with ID: %s already exists", resourceType, resourceID)
+
+	apiErr := perun.NewAPIErrResourceExists(resourceType, resourceID)
+	peruntest.AssertAPIError(t, apiErr, perun.ClientError, perun.ErrResourceExists, wantMsg)
+	peruntest.AssertErrInfoResourceExists(t, apiErr.AddInfo(), resourceType, resourceID)
 }
 
 func Test_NewErrInvalidArgument(t *testing.T) {
-	resourceType := "any-type"
-	resourceID := "any-id"
-	requirement := "any-requirement"
-	message := "any-message"
+	name := perun.ArgumentName("any-name")
+	value := "any-value"
+	err := errors.New("any-error")
+	wantMsg := fmt.Sprintf("invalid value for %s: %s: %v", name, value, err)
 
-	err := perun.NewAPIErrInvalidArgument(resourceType, resourceID, requirement, message)
-	require.NotNil(t, err)
+	apiErr := perun.NewAPIErrInvalidArgument(err, name, value)
+	peruntest.AssertAPIError(t, apiErr, perun.ClientError, perun.ErrInvalidArgument, wantMsg)
+	peruntest.AssertErrInfoInvalidArgument(t, apiErr.AddInfo(), name, value)
+}
 
-	assert.Equal(t, perun.ClientError, err.Category())
-	assert.Equal(t, perun.ErrInvalidArgument, err.Code())
-	assert.Equal(t, message, err.Message())
-	addInfo, ok := err.AddInfo().(perun.ErrInfoInvalidArgument)
-	require.True(t, ok)
-	assert.Equal(t, addInfo.Name, resourceType)
-	assert.Equal(t, addInfo.Value, resourceID)
-	assert.Equal(t, addInfo.Requirement, requirement)
-	t.Log(err.Error())
+func Test_NewErrFailedPreCondition(t *testing.T) {
+	err := errors.New("any-error")
+	wantMsg := fmt.Sprintf("failed pre-condition: %v", err)
+
+	apiErr := perun.NewAPIErrFailedPreCondition(err)
+	peruntest.AssertAPIError(t, apiErr, perun.ClientError, perun.ErrFailedPreCondition, wantMsg)
+}
+
+func Test_NewErrFailedPreConditionUnclosedChs(t *testing.T) {
+	err := errors.New("session cannot be closed with channels in unexpected phase")
+	wantMsg := fmt.Sprintf("failed pre-condition: %v", err)
+	unclosedChs := []perun.ChInfo{
+		{
+			ChID:    "one",
+			Version: "1",
+		},
+	}
+
+	apiErr := perun.NewAPIErrFailedPreConditionUnclosedChs(err, unclosedChs)
+	peruntest.AssertAPIError(t, apiErr, perun.ClientError, perun.ErrFailedPreCondition, wantMsg)
+	peruntest.AssertErrInfoFailedPreCondUnclosedChs(t, apiErr.AddInfo(), unclosedChs)
+}
+
+func Test_NewErrInvalidConfig(t *testing.T) {
+	name := "any-name"
+	value := "any-value"
+	err := errors.New("any-error")
+	wantMsg := fmt.Sprintf("invalid value for %s: %s: %v", name, value, err)
+
+	apiErr := perun.NewAPIErrInvalidConfig(err, name, value)
+	peruntest.AssertAPIError(t, apiErr, perun.ClientError, perun.ErrInvalidConfig, wantMsg)
+	peruntest.AssertErrInfoInvalidConfig(t, apiErr.AddInfo(), name, value)
+}
+
+func Test_NewErrInvalidContracts(t *testing.T) {
+	contractErrInfos := []perun.ContractErrInfo{
+		{"contracts-1", "addr 1", errors.New("1").Error()},
+		{"contracts-2", "addr 2", errors.New("2").Error()},
+	}
+	contractsErrInfosMsg := ""
+	for _, c := range contractErrInfos {
+		contractsErrInfosMsg += fmt.Sprintf("(%s at address %s: %v) ", c.Name, c.Address, c.Error)
+	}
+	wantMsg := "invalid contracts: " + contractsErrInfosMsg
+
+	apiErr := perun.NewAPIErrInvalidContracts(contractErrInfos)
+	peruntest.AssertAPIError(t, apiErr, perun.ClientError, perun.ErrInvalidContracts, wantMsg)
+	peruntest.AssertErrInfoInvalidContracts(t, apiErr.AddInfo(), contractErrInfos)
+}
+
+func Test_NewErrTxTimedOut(t *testing.T) {
+	txType := "any-type"
+	txID := "any-id"
+	txTimeout := "10m1s"
+	err := errors.New("any-error")
+	wantMsg := fmt.Sprintf("timed out waiting for %s tx (ID:%s) to be mined in %s: %v", txType, txID, txTimeout, err)
+
+	apiErr := perun.NewAPIErrTxTimedOut(err, txType, txID, txTimeout)
+	peruntest.AssertAPIError(t, apiErr, perun.ProtocolFatalError, perun.ErrTxTimedOut, wantMsg)
+	peruntest.AssertErrInfoTxTimedOut(t, apiErr.AddInfo(), txType, txID, txTimeout)
+}
+
+func Test_NewErrChainNotReachable(t *testing.T) {
+	chainURL := "any-chain-url"
+	err := errors.New("any-error")
+	wantMsg := fmt.Sprintf("chain not reachable at URL %s: %v", chainURL, err)
+
+	apiErr := perun.NewAPIErrChainNotReachable(err, chainURL)
+	peruntest.AssertAPIError(t, apiErr, perun.ProtocolFatalError, perun.ErrChainNotReachable, wantMsg)
+	peruntest.AssertErrInfoChainNotReachable(t, apiErr.AddInfo(), chainURL)
+}
+
+func Test_NewErrUnknownInternal(t *testing.T) {
+	err := errors.New("any-error")
+	wantMsg := fmt.Sprintf("unknown internal error: %v", err)
+
+	apiErr := perun.NewAPIErrUnknownInternal(err)
+	peruntest.AssertAPIError(t, apiErr, perun.InternalError, perun.ErrUnknownInternal, wantMsg)
+}
+
+func Test_APIErrAsMap(t *testing.T) {
+	method := "test method"
+	apiErr := perun.NewAPIErrUnknownInternal(errors.New("any-error"))
+	errAsMap := perun.APIErrAsMap(method, apiErr)
+	assert.Equal(t, errAsMap, map[string]interface{}{
+		"method":   method,
+		"category": perun.InternalError.String(),
+		"code":     perun.ErrUnknownInternal,
+	})
 }

--- a/node/node.go
+++ b/node/node.go
@@ -43,11 +43,6 @@ func (e Error) Error() string {
 	return string(e)
 }
 
-// Definition of error constants for this package.
-const (
-	ErrUnknownSessionID Error = "unknown session id"
-)
-
 // New returns a perun NodeAPI instance initialized using the given config.
 // This should be called only once, subsequent calls after the first non error
 // response will return an error.
@@ -78,26 +73,34 @@ func New(cfg perun.NodeConfig) (perun.NodeAPI, error) {
 	}, nil
 }
 
-// Time returns the current UTC time as per the node's system clock in unix format.
+// Time returns the time as per perun node's clock. It should be used to check
+// the expiry of notifications.
 func (n *node) Time() int64 {
 	n.Debug("Received request: node.Time")
 	return time.Now().UTC().Unix()
 }
 
-// GetConfig returns the node level configuration parameters.
+// GetConfig returns the configuration parameters of the node.
 func (n *node) GetConfig() perun.NodeConfig {
 	n.Debug("Received request: node.GetConfig")
 	return n.cfg
 }
 
-// Help returns the set of APIs offered by the node.
+// Help returns the list of user APIs served by the node.
 func (n *node) Help() []string {
 	n.Debug("Received request: node.Help")
 	return []string{"payment"}
 }
 
-// OpenSession opens a session on this node using the given config file and returns the
-// session id, which can be used to retrieve a SessionAPI instance from this node instance.
+// Initializes a new session with the configuration in the given file. If
+// channels were persisted during the previous instance of the session, they
+// will be restored and their last known info will be returned.
+//
+// If there is an error, it will be one of the following codes:
+// - ErrInvalidArgument with Name:"configFile" when config file cannot be accessed.
+// - ErrInvalidConfig when any of the configuration is invalid.
+// - ErrInvalidContracts when the contracts at the addresses in config are invalid.
+// - ErrUnknownInternal
 func (n *node) OpenSession(configFile string) (string, []perun.ChInfo, perun.APIError) {
 	n.WithField("method", "OpenSession").Infof("\nReceived request with params %+v", configFile)
 	n.Lock()
@@ -113,7 +116,7 @@ func (n *node) OpenSession(configFile string) (string, []perun.ChInfo, perun.API
 	sessionConfig, err := session.ParseConfig(configFile)
 	if err != nil {
 		err = errors.WithMessage(err, "parsing config")
-		return "", nil, perun.NewAPIErrInvalidArgument("configFile", configFile, "", err.Error())
+		return "", nil, perun.NewAPIErrInvalidArgument(err, session.ArgNameConfigFile, configFile)
 	}
 	sess, apiErr := session.New(sessionConfig)
 	if apiErr != nil {
@@ -125,7 +128,13 @@ func (n *node) OpenSession(configFile string) (string, []perun.ChInfo, perun.API
 	return sess.ID(), sess.GetChsInfo(), nil
 }
 
-// GetSession implements node.GetSession.
+// GetSession is an internal API that retreives the session API instance
+// corresponding to the given session ID.
+//
+// The session instance is safe for concurrent user.
+//
+// If there is an error, it will be one of the following codes:
+// - ErrResourceNotFound when the session ID is not known.
 func (n *node) GetSession(sessionID string) (perun.SessionAPI, perun.APIError) {
 	n.WithField("method", "GetSession").Info("Received request with params:", sessionID)
 
@@ -133,7 +142,7 @@ func (n *node) GetSession(sessionID string) (perun.SessionAPI, perun.APIError) {
 	sess, ok := n.sessions[sessionID]
 	n.Unlock()
 	if !ok {
-		apiErr := perun.NewAPIErrResourceNotFound("session id", sessionID, ErrUnknownSessionID.Error())
+		apiErr := perun.NewAPIErrResourceNotFound(session.ResTypeSession, sessionID)
 		n.WithFields(perun.APIErrAsMap("GetSession (internal)", apiErr)).Error(apiErr.Message())
 		return nil, apiErr
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -100,7 +100,7 @@ func (n *node) Help() []string {
 // - ErrInvalidArgument with Name:"configFile" when config file cannot be accessed.
 // - ErrInvalidConfig when any of the configuration is invalid.
 // - ErrInvalidContracts when the contracts at the addresses in config are invalid.
-// - ErrUnknownInternal
+// - ErrUnknownInternal.
 func (n *node) OpenSession(configFile string) (string, []perun.ChInfo, perun.APIError) {
 	n.WithField("method", "OpenSession").Infof("\nReceived request with params %+v", configFile)
 	n.Lock()

--- a/node/node_integ_test.go
+++ b/node/node_integ_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/hyperledger-labs/perun-node/blockchain/ethereum/ethereumtest"
 	"github.com/hyperledger-labs/perun-node/node"
 	"github.com/hyperledger-labs/perun-node/node/nodetest"
+	"github.com/hyperledger-labs/perun-node/peruntest"
+	"github.com/hyperledger-labs/perun-node/session"
 	"github.com/hyperledger-labs/perun-node/session/sessiontest"
 )
 
@@ -111,13 +113,8 @@ func Test_Integ_New(t *testing.T) {
 	t.Run("err_GetSession_not_found", func(t *testing.T) {
 		unknownSessID := "unknown session id"
 		_, err := n.GetSession(unknownSessID)
-		require.Error(t, err)
 
-		wantMessage := node.ErrUnknownSessionID.Error()
-		assert.Equal(t, perun.ClientError, err.Category())
-		assert.Equal(t, perun.ErrResourceNotFound, err.Code())
-		assert.Equal(t, wantMessage, err.Message())
-		assertErrInfoResourceNotFound(t, err.AddInfo(), "session id", unknownSessID)
+		peruntest.AssertErrInfoResourceNotFound(t, err.AddInfo(), session.ResTypeSession, unknownSessID)
 	})
 
 	// Simulate one error to fail session.New and check if err is not nil.
@@ -130,13 +127,4 @@ func Test_Integ_New(t *testing.T) {
 		_, _, err := n.OpenSession(sessionCfgFile)
 		require.Error(t, err)
 	})
-}
-
-func assertErrInfoResourceNotFound(t *testing.T, info interface{}, resourceType, resourceID string) {
-	t.Helper()
-
-	addInfo, ok := info.(perun.ErrInfoResourceNotFound)
-	require.True(t, ok)
-	assert.Equal(t, resourceType, addInfo.Type)
-	assert.Equal(t, resourceID, addInfo.ID)
 }

--- a/peruntest/assert.go
+++ b/peruntest/assert.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2020 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository at
+// https://github.com/hyperledger-labs/perun-node
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peruntest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/perun-node"
+)
+
+// AssertAPIError tests if the passed error contains expected category, code
+// and phrases in the message.
+func AssertAPIError(t *testing.T, e perun.APIError, categ perun.ErrorCategory, code perun.ErrorCode, msgs ...string) {
+	t.Helper()
+
+	require.Error(t, e)
+	assert.Equal(t, categ, e.Category())
+	assert.Equal(t, code, e.Code())
+	for _, msg := range msgs {
+		assert.Contains(t, e.Message(), msg)
+	}
+}
+
+// AssertErrInfoPeerRequestTimedOut tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoPeerRequestTimedOut(t *testing.T, info interface{}, peerAlias, timeout string) {
+	t.Helper()
+
+	addInfo, ok := info.(perun.ErrInfoPeerRequestTimedOut)
+	require.True(t, ok)
+	assert.Equal(t, peerAlias, addInfo.PeerAlias)
+	assert.Equal(t, timeout, addInfo.Timeout)
+}
+
+// AssertErrInfoPeerRejected tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoPeerRejected(t *testing.T, info interface{}, peerAlias, reason string) {
+	t.Helper()
+
+	addInfo, ok := info.(perun.ErrInfoPeerRejected)
+	require.True(t, ok)
+	assert.Equal(t, peerAlias, addInfo.PeerAlias)
+	assert.Equal(t, reason, addInfo.Reason)
+}
+
+// AssertErrInfoPeerNotFunded tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoPeerNotFunded(t *testing.T, info interface{}, peerAlias string) {
+	t.Helper()
+
+	addInfo, ok := info.(perun.ErrInfoPeerNotFunded)
+	require.True(t, ok)
+	assert.Equal(t, peerAlias, addInfo.PeerAlias)
+}
+
+// AssertErrInfoUserResponseTimedOut tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoUserResponseTimedOut(t *testing.T, info interface{}) {
+	t.Helper()
+
+	addInfo, ok := info.(perun.ErrInfoUserResponseTimedOut)
+	require.True(t, ok)
+	assert.Less(t, addInfo.Expiry, addInfo.ReceivedAt)
+}
+
+// AssertErrInfoResourceNotFound tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoResourceNotFound(t *testing.T, info interface{}, resourceType perun.ResourceType, id string) {
+	t.Helper()
+
+	addInfo, ok := info.(perun.ErrInfoResourceNotFound)
+	require.True(t, ok)
+	assert.Equal(t, string(resourceType), addInfo.Type)
+	assert.Equal(t, id, addInfo.ID)
+}
+
+// AssertErrInfoResourceExists tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoResourceExists(t *testing.T, info interface{}, resourceType perun.ResourceType, id string) {
+	t.Helper()
+
+	addInfo, ok := info.(perun.ErrInfoResourceExists)
+	require.True(t, ok)
+	assert.Equal(t, string(resourceType), addInfo.Type)
+	assert.Equal(t, id, addInfo.ID)
+}
+
+// AssertErrInfoInvalidArgument tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoInvalidArgument(t *testing.T, info interface{}, name perun.ArgumentName, value string) {
+	t.Helper()
+
+	addInfo, ok := info.(perun.ErrInfoInvalidArgument)
+	require.True(t, ok)
+	assert.Equal(t, string(name), addInfo.Name)
+	assert.Equal(t, value, addInfo.Value)
+	t.Log("requirement:", addInfo.Requirement)
+}
+
+// AssertErrInfoFailedPreCondUnclosedChs tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoFailedPreCondUnclosedChs(t *testing.T, info interface{}, chInfos []perun.ChInfo) {
+	t.Helper()
+
+	addInfo, ok := info.(perun.ErrInfoFailedPreCondUnclosedChs)
+	require.True(t, ok)
+	assert.Equal(t, chInfos, addInfo.ChInfos)
+}
+
+// AssertErrInfoInvalidConfig tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoInvalidConfig(t *testing.T, info interface{}, name, value string) {
+	t.Helper()
+
+	addInfo, ok := info.(perun.ErrInfoInvalidConfig)
+	require.True(t, ok)
+	assert.Equal(t, name, addInfo.Name)
+	assert.Equal(t, value, addInfo.Value)
+}
+
+// AssertErrInfoInvalidContracts tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoInvalidContracts(t *testing.T, info interface{}, contractErrInfos []perun.ContractErrInfo) {
+	t.Helper()
+
+	_, ok := info.(perun.ErrInfoInvalidContracts)
+	require.True(t, ok)
+	// TODO: compare the two list based on matching keys.
+	// assert.Len(t, len(contractErrInfos), len(addInfo.ContractErrInfos))
+}
+
+// AssertErrInfoTxTimedOut tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoTxTimedOut(t *testing.T, info interface{}, txType, txID, txTimeout string) {
+	t.Helper()
+
+	addInfo, ok := info.(perun.ErrInfoTxTimedOut)
+	require.True(t, ok)
+	assert.Equal(t, txType, addInfo.TxType)
+	assert.Equal(t, txID, addInfo.TxID)
+	assert.Equal(t, txTimeout, addInfo.TxTimeout)
+}
+
+// AssertErrInfoChainNotReachable tests if additional info field is of
+// correct type and has expected values.
+func AssertErrInfoChainNotReachable(t *testing.T, info interface{}, chainURL string) {
+	t.Helper()
+
+	addInfo, ok := info.(perun.ErrInfoChainNotReachable)
+	require.True(t, ok)
+	assert.Equal(t, chainURL, addInfo.ChainURL)
+}

--- a/peruntest/doc.go
+++ b/peruntest/doc.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository at
+// https://github.com/hyperledger-labs/perun-node
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package peruntest implements test helpers for functionalities defined in perun package.
+package peruntest

--- a/session/channel.go
+++ b/session/channel.go
@@ -289,7 +289,7 @@ func (ch *Channel) ChallengeDurSecs() uint64 {
 // - ErrInvalidArgument with Name:"Amount" when any of the amounts is invalid.
 // - ErrPeerRequestTimedOut when peer request times out.
 // - ErrPeerRejected when peer rejects the request.
-// - ErrUnknownInternal
+// - ErrUnknownInternal.
 func (ch *Channel) SendChUpdate(pctx context.Context, updater perun.StateUpdater) (perun.ChInfo, perun.APIError) {
 	ch.WithField("method", "SendChUpdate").Infof("\nReceived request with params %+v", updater)
 	ch.Lock()
@@ -461,15 +461,15 @@ func (ch *Channel) unsubChUpdates() {
 	ch.chUpdateNotifier = nil
 }
 
-// Responds to an incoming channel update for which a notification had been
-// received. Response should be sent before the notification expires. Use the
-// `Time` API to fetch current time of the perun node for checking notification
-// expiry.
+// RespondChUpdate responds to an incoming channel update for which a
+// notification had been received. Response should be sent before the
+// notification expires. Use the `Time` API to fetch current time of the perun
+// node for checking notification expiry.
 //
 // If there is an error, it will be one of the following codes:
 // - ErrResourceNotFound with ResourceType: "update" when update ID is not known.
 // - ErrUserResponseTimedOut when user responded after time out expired.
-// - ErrUnknownInternal
+// - ErrUnknownInternal.
 func (ch *Channel) RespondChUpdate(pctx context.Context, updateID string, accept bool) (
 	perun.ChInfo, perun.APIError) {
 	ch.WithField("method", "RespondChUpdate").Infof("\nReceived request with params %+v,%+v", updateID, accept)
@@ -600,11 +600,11 @@ func makeBalInfoFromRawBal(parts []string, curr string, rawBal []*big.Int) perun
 	return balInfo
 }
 
-// Closes the channel. First it tries to finalize the last agreed state of the
-// payment channel off-chain (by sending a finalizing update) and then settling it
-// on the blockchan. If the channel participants reject/not respond to the
-// finalizing update, the last agreed state will be finalized directly on the
-// blockchain. The call will return after this.
+// Close closes the channel. First it tries to finalize the last agreed state
+// of the payment channel off-chain (by sending a finalizing update) and then
+// settling it on the blockchain. If the channel participants reject/not
+// respond to the finalizing update, the last agreed state will be finalized
+// directly on the blockchain. The call will return after this.
 //
 // The node will then wait for the challenge duration to pass (if the channel was
 // directly settled on the blockchain) and the withdraw the balance as per the
@@ -620,7 +620,7 @@ func makeBalInfoFromRawBal(parts []string, curr string, rawBal []*big.Int) perun
 // If there is an error returned by this API, it will be one of the following codes:
 // - ErrTxTimedOut with TxType: "Register" when register tx times out.
 // - ErrChainNotReachable when connection to blockchain drops while register.
-// - ErrUnknownInternal
+// - ErrUnknownInternal.
 func (ch *Channel) Close(pctx context.Context) (perun.ChInfo, perun.APIError) {
 	ch.WithField("method", "ChClose").Infof("\nReceived request")
 	ch.Lock()

--- a/session/client.go
+++ b/session/client.go
@@ -163,7 +163,7 @@ func newEthereumPaymentClient(cfg clientConfig, user User, comm perun.CommBacken
 
 	listener, err := comm.NewListener(user.CommAddr)
 	if err != nil {
-		return nil, perun.NewAPIErrInvalidConfig("commAddr", user.CommAddr, err.Error())
+		return nil, perun.NewAPIErrInvalidConfig(err, "commAddr", user.CommAddr)
 	}
 	c.runAsGoRoutine(func() { msgBus.Listen(listener) })
 
@@ -224,17 +224,17 @@ func connectToChain(cfg chainConfig, cred perun.Credential) (pchannel.Funder, pc
 	walletBackend := ethereum.NewWalletBackend()
 	assetAddr, err := walletBackend.ParseAddr(cfg.Asset)
 	if err != nil {
-		return nil, nil, perun.NewAPIErrInvalidConfig("asset", cfg.Asset, err.Error())
+		return nil, nil, perun.NewAPIErrInvalidConfig(err, "asset", cfg.Asset)
 	}
 	adjudicatorAddr, err := walletBackend.ParseAddr(cfg.Adjudicator)
 	if err != nil {
-		return nil, nil, perun.NewAPIErrInvalidConfig("adjudicator", cfg.Adjudicator, err.Error())
+		return nil, nil, perun.NewAPIErrInvalidConfig(err, "adjudicator", cfg.Adjudicator)
 	}
 
 	chain, err := ethereum.NewChainBackend(cfg.URL, cfg.ChainID, cfg.ConnTimeout, cfg.OnChainTxTimeout, cred)
 	if err != nil {
 		err = errors.WithMessage(err, "connecting to blockchain")
-		return nil, nil, perun.NewAPIErrInvalidConfig("chainURL", cfg.URL, err.Error())
+		return nil, nil, perun.NewAPIErrInvalidConfig(err, "chainURL", cfg.URL)
 	}
 	adjErr := chain.ValidateAdjudicator(adjudicatorAddr)
 	assetHolderErr := chain.ValidateAssetHolderETH(adjudicatorAddr, assetAddr)

--- a/session/session.go
+++ b/session/session.go
@@ -286,7 +286,7 @@ func (s *Session) handleRestoredCh(pch PChannel) {
 // - ErrResourceExists with ResourceType: "peerID" when peer ID is already registered
 // - ErrInvalidArgument with Name:"peerAlias" when peer alias is used for another peer,
 // - ErrInvalidArgument with Name:"offChainAddress" when off-chain address is invalid.
-// - ErrUnknownInternal
+// - ErrUnknownInternal.
 func (s *Session) AddPeerID(peerID perun.PeerID) perun.APIError {
 	s.WithField("method", "AddPeerID").Info("Received request with params:", peerID)
 	s.Lock()
@@ -323,7 +323,7 @@ func (s *Session) AddPeerID(peerID perun.PeerID) perun.APIError {
 // of the session.
 //
 // If there is errors, it will be one of the following codes:
-// - ErrResourceNotFound with ResourceType: "peerID" when peer alias is not known,
+// - ErrResourceNotFound with ResourceType: "peerID" when peer alias is not known.
 func (s *Session) GetPeerID(alias string) (perun.PeerID, perun.APIError) {
 	s.WithField("method", "GetPeerID").Info("Received request with params:", alias)
 	s.Lock()
@@ -362,7 +362,7 @@ func (s *Session) GetPeerID(alias string) (perun.PeerID, perun.APIError) {
 // - ErrPeerNotFunded when peer did not fund the channel in time.
 // - ErrTxTimedOut with TxType: "Fund" when funding tx times out.
 // - ErrChainNotReachable when connection to blockchain drops while funding.
-// - ErrUnknownInternal
+// - ErrUnknownInternal.
 func (s *Session) OpenCh(pctx context.Context, openingBalInfo perun.BalInfo, app perun.App, challengeDurSecs uint64) (
 	perun.ChInfo, perun.APIError) {
 	s.WithField("method", "OpenCh").Infof(
@@ -732,7 +732,7 @@ func (s *Session) UnsubChProposals() perun.APIError {
 // - ErrUserResponseTimedOut when user responded after time out expired.
 // - ErrTxTimedOut with TxType: "Fund" when there is tx timed error while funding.
 // - ErrChainNotReachable when connection to blockchain drops while funding.
-// - ErrUnknownInternal
+// - ErrUnknownInternal.
 func (s *Session) RespondChProposal(pctx context.Context, chProposalID string, accept bool) (
 	perun.ChInfo, perun.APIError) {
 	s.WithField("method", "RespondChProposal").Infof("\nReceived request with Params %+v,%+v", chProposalID, accept)
@@ -921,7 +921,7 @@ func (s *Session) HandleUpdateWInterface(
 // - ErrFailedPreCondition when session is closed with force=false and unclosed channels
 //   exists. Additional Info will contain an extra field: OpenChannelsInfo
 //   that contains a list of Channel Info.
-// - ErrUnknownInternal
+// - ErrUnknownInternal.
 func (s *Session) Close(force bool) ([]perun.ChInfo, perun.APIError) {
 	s.WithField("method", "Close").Infof("\nReceived request with params %+v", force)
 	s.Debug("Received request: session.Close")

--- a/session/session_integ_test.go
+++ b/session/session_integ_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/hyperledger-labs/perun-node/blockchain/ethereum/ethereumtest"
 	"github.com/hyperledger-labs/perun-node/comm/tcp"
 	"github.com/hyperledger-labs/perun-node/idprovider/idprovidertest"
+	"github.com/hyperledger-labs/perun-node/peruntest"
 	"github.com/hyperledger-labs/perun-node/session"
 	"github.com/hyperledger-labs/perun-node/session/sessiontest"
 )
@@ -82,8 +83,8 @@ func Test_Integ_New(t *testing.T) {
 
 		_, apiErr = session.New(cfgCopy)
 		require.Error(t, apiErr)
-		assertAPIError(t, apiErr, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, apiErr.AddInfo(), "databaseDir", cfgCopy.DatabaseDir)
+		peruntest.AssertAPIError(t, apiErr, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, apiErr.AddInfo(), "databaseDir", cfgCopy.DatabaseDir)
 	})
 	t.Run("invalidConfig_chainURL", func(t *testing.T) {
 		cfgCopy := cfg
@@ -91,8 +92,8 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.ChainURL = "invalid-url"
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "chainURL", cfgCopy.ChainURL)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "chainURL", cfgCopy.ChainURL)
 	})
 	t.Run("invalidConfig_chainURL_chainConnTimeout", func(t *testing.T) {
 		cfgCopy := cfg
@@ -100,8 +101,8 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.ChainConnTimeout = 0
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "chainURL", cfgCopy.ChainURL)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "chainURL", cfgCopy.ChainURL)
 	})
 
 	t.Run("invalidConfig_onChainAddr", func(t *testing.T) {
@@ -110,8 +111,8 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.User.OnChainAddr = "invalid-addr" //nolint: goconst	// it's okay to repeat this phrase.
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "onChainAddr", cfgCopy.User.OnChainAddr)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "onChainAddr", cfgCopy.User.OnChainAddr)
 	})
 	t.Run("invalidConfig_offChainAddr", func(t *testing.T) {
 		cfgCopy := cfg
@@ -119,8 +120,8 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.User.OffChainAddr = "invalid-addr"
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "offChainAddr", cfgCopy.User.OffChainAddr)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "offChainAddr", cfgCopy.User.OffChainAddr)
 	})
 	t.Run("invalidConfig_onChainWallet_password", func(t *testing.T) {
 		cfgCopy := cfg
@@ -129,8 +130,8 @@ func Test_Integ_New(t *testing.T) {
 		wantValue := fmt.Sprintf("%s, %s", cfgCopy.User.OnChainWallet.KeystorePath, cfgCopy.User.OnChainWallet.Password)
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "onChainWallet", wantValue)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "onChainWallet", wantValue)
 	})
 	t.Run("invalidConfig_offChainWallet_password", func(t *testing.T) {
 		cfgCopy := cfg
@@ -139,8 +140,8 @@ func Test_Integ_New(t *testing.T) {
 		wantValue := fmt.Sprintf("%s, %s", cfgCopy.User.OffChainWallet.KeystorePath, cfgCopy.User.OffChainWallet.Password)
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "offChainWallet", wantValue)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "offChainWallet", wantValue)
 	})
 
 	t.Run("invalidConfig_adjudicator", func(t *testing.T) {
@@ -149,8 +150,8 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.Adjudicator = "invalid-addr"
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "adjudicator", cfgCopy.Adjudicator)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "adjudicator", cfgCopy.Adjudicator)
 	})
 	t.Run("invalidConfig_asset", func(t *testing.T) {
 		cfgCopy := cfg
@@ -158,8 +159,8 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.Asset = "invalid-addr"
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "asset", cfgCopy.Asset)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "asset", cfgCopy.Asset)
 	})
 	t.Run("invalid_adjudicator_contract", func(t *testing.T) {
 		cfgCopy := cfg
@@ -167,15 +168,15 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.Adjudicator = ethereumtest.NewRandomAddress(prng).String()
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidContracts, "")
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidContracts, "")
 		// Both contracts will be returned as invalid because, the asset holder
 		// validation function in go-perun passes only if both adjudicator and
 		// asset holder contracts are valid.
-		wantContractsInfo := map[string]string{
-			string(blockchain.Adjudicator):    cfgCopy.Adjudicator,
-			string(blockchain.AssetHolderETH): cfgCopy.Asset,
+		wantContractsInfo := []perun.ContractErrInfo{
+			{Name: string(blockchain.Adjudicator), Address: cfgCopy.Adjudicator},
+			{Name: string(blockchain.AssetHolderETH), Address: cfgCopy.Asset},
 		}
-		assertErrInfoInvalidContracts(t, err.AddInfo(), 2, wantContractsInfo)
+		peruntest.AssertErrInfoInvalidContracts(t, err.AddInfo(), wantContractsInfo)
 	})
 	t.Run("invalid_asset_contract", func(t *testing.T) {
 		cfgCopy := cfg
@@ -183,11 +184,11 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.Asset = ethereumtest.NewRandomAddress(prng).String()
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidContracts, "")
-		wantContractsInfo := map[string]string{
-			string(blockchain.AssetHolderETH): cfgCopy.Asset,
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidContracts, "")
+		wantContractsInfo := []perun.ContractErrInfo{
+			{Name: string(blockchain.AssetHolderETH), Address: cfgCopy.Asset},
 		}
-		assertErrInfoInvalidContracts(t, err.AddInfo(), 1, wantContractsInfo)
+		peruntest.AssertErrInfoInvalidContracts(t, err.AddInfo(), wantContractsInfo)
 	})
 	t.Run("invalid_adjudicator_asset_contract", func(t *testing.T) {
 		cfgCopy := cfg
@@ -196,12 +197,12 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.Asset = ethereumtest.NewRandomAddress(prng).String()
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidContracts, "")
-		wantContractsInfo := map[string]string{
-			string(blockchain.Adjudicator):    cfgCopy.Adjudicator,
-			string(blockchain.AssetHolderETH): cfgCopy.Asset,
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidContracts, "")
+		wantContractsInfo := []perun.ContractErrInfo{
+			{Name: string(blockchain.Adjudicator), Address: cfgCopy.Adjudicator},
+			{Name: string(blockchain.AssetHolderETH), Address: cfgCopy.Asset},
 		}
-		assertErrInfoInvalidContracts(t, err.AddInfo(), 2, wantContractsInfo)
+		peruntest.AssertErrInfoInvalidContracts(t, err.AddInfo(), wantContractsInfo)
 	})
 
 	t.Run("invalidConfig_commType", func(t *testing.T) {
@@ -210,8 +211,8 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.User.CommType = "unsupported"
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "commType", cfgCopy.User.CommType)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "commType", cfgCopy.User.CommType)
 	})
 	t.Run("invalidConfig_commAddr", func(t *testing.T) {
 		cfgCopy := cfg
@@ -219,8 +220,8 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.User.CommAddr = "invalid-addr"
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "commAddr", cfgCopy.User.CommAddr)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "commAddr", cfgCopy.User.CommAddr)
 	})
 	t.Run("invalidConfig_commAddr_portInUse", func(t *testing.T) {
 		cfgCopy := cfg
@@ -240,8 +241,8 @@ func Test_Integ_New(t *testing.T) {
 
 		_, apiErr := session.New(cfgCopy)
 		require.Error(t, apiErr)
-		assertAPIError(t, apiErr, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, apiErr.AddInfo(), "commAddr", cfgCopy.User.CommAddr)
+		peruntest.AssertAPIError(t, apiErr, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, apiErr.AddInfo(), "commAddr", cfgCopy.User.CommAddr)
 	})
 
 	t.Run("invalidConfig_idProviderType", func(t *testing.T) {
@@ -250,8 +251,8 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.IDProviderType = "unsupported"
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "idProviderType", cfgCopy.IDProviderType)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "idProviderType", cfgCopy.IDProviderType)
 	})
 	t.Run("invalidConfig_idProviderURL", func(t *testing.T) {
 		cfgCopy := cfg
@@ -259,8 +260,8 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.IDProviderURL = newCorruptedYAMLFile(t)
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "idProviderURL", cfgCopy.IDProviderURL)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "idProviderURL", cfgCopy.IDProviderURL)
 	})
 	t.Run("invalidConfig_idProviderURL_hasEntryForSelf", func(t *testing.T) {
 		ownPeer := perun.PeerID{
@@ -271,8 +272,9 @@ func Test_Integ_New(t *testing.T) {
 		cfgCopy.IDProviderURL = idprovidertest.NewIDProviderT(t, ownPeer)
 		_, err := session.New(cfgCopy)
 		require.Error(t, err)
-		assertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		assertErrInfoInvalidConfig(t, err.AddInfo(), "idProviderURL", cfgCopy.IDProviderURL)
+		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
+		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "idProviderURL", cfgCopy.IDProviderURL)
+		t.Logf("%+v", err)
 	})
 }
 
@@ -367,25 +369,25 @@ func newDatabaseDir(t *testing.T) (dir string) {
 	return databaseDir
 }
 
-func assertErrInfoInvalidConfig(t *testing.T, info interface{}, name, value string) {
-	t.Helper()
+// func peruntest.AssertErrInfoInvalidConfig(t *testing.T, info interface{}, name, value string) {
+// 	t.Helper()
 
-	addInfo, ok := info.(perun.ErrInfoInvalidConfig)
-	require.True(t, ok)
-	assert.Equal(t, name, addInfo.Name)
-	assert.Equal(t, value, addInfo.Value)
-}
+// 	addInfo, ok := info.(perun.ErrInfoInvalidConfig)
+// 	require.True(t, ok)
+// 	assert.Equal(t, name, addInfo.Name)
+// 	assert.Equal(t, value, addInfo.Value)
+// }
 
-func assertErrInfoInvalidContracts(t *testing.T, info interface{}, cntContracts int, wantInfo map[string]string) {
-	t.Helper()
+// func .AssertErrInfoInvalidContracts(t *testing.T, info interface{}, cntContracts int, wantInfo map[string]string) {
+// 	t.Helper()
 
-	addInfo, ok := info.(perun.ErrInfoInvalidContracts)
-	require.True(t, ok)
-	assert.Len(t, addInfo.ContractErrInfos, cntContracts)
-	assert.Len(t, wantInfo, cntContracts, "length of wantInfo should be same as count of invalid contracts")
-	for i := range addInfo.ContractErrInfos {
-		addr, ok := wantInfo[addInfo.ContractErrInfos[i].Name]
-		require.True(t, ok)
-		assert.Equal(t, addr, addInfo.ContractErrInfos[i].Address)
-	}
-}
+// 	addInfo, ok := info.(perun.ErrInfoInvalidContracts)
+// 	require.True(t, ok)
+// 	assert.Len(t, addInfo.ContractErrInfos, cntContracts)
+// 	assert.Len(t, wantInfo, cntContracts, "length of wantInfo should be same as count of invalid contracts")
+// 	for i := range addInfo.ContractErrInfos {
+// 		addr, ok := wantInfo[addInfo.ContractErrInfos[i].Name]
+// 		require.True(t, ok)
+// 		assert.Equal(t, addr, addInfo.ContractErrInfos[i].Address)
+// 	}
+// }

--- a/session/user.go
+++ b/session/user.go
@@ -43,19 +43,19 @@ func NewUnlockedUser(wb perun.WalletBackend, cfg UserConfig) (User, perun.APIErr
 
 	onChainAddr, err := wb.ParseAddr(cfg.OnChainAddr)
 	if err != nil {
-		return User{}, perun.NewAPIErrInvalidConfig("onChainAddr", cfg.OnChainAddr, err.Error())
+		return User{}, perun.NewAPIErrInvalidConfig(err, "onChainAddr", cfg.OnChainAddr)
 	}
 	offChainAddr, err := wb.ParseAddr(cfg.OffChainAddr)
 	if err != nil {
-		return User{}, perun.NewAPIErrInvalidConfig("offChainAddr", cfg.OffChainAddr, err.Error())
+		return User{}, perun.NewAPIErrInvalidConfig(err, "offChainAddr", cfg.OffChainAddr)
 	}
 	if u.OnChain, err = newCred(wb, cfg.OnChainWallet, onChainAddr); err != nil {
 		value := fmt.Sprintf("%s, %s", cfg.OnChainWallet.KeystorePath, cfg.OnChainWallet.Password)
-		return User{}, perun.NewAPIErrInvalidConfig("onChainWallet", value, err.Error())
+		return User{}, perun.NewAPIErrInvalidConfig(err, "onChainWallet", value)
 	}
 	if u.OffChain, err = newCred(wb, cfg.OffChainWallet, offChainAddr); err != nil {
 		value := fmt.Sprintf("%s, %s", cfg.OffChainWallet.KeystorePath, cfg.OffChainWallet.Password)
-		return User{}, perun.NewAPIErrInvalidConfig("offChainWallet", value, err.Error())
+		return User{}, perun.NewAPIErrInvalidConfig(err, "offChainWallet", value)
 	}
 
 	u.PeerID.Alias = perun.OwnAlias


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->
- The implementation is improved to
  - Store the underlying error, so that error stack can be retreived.
  - Implement formatter interface, so that error stack is retreived from
    the underlying error and printed when using the "%+v" verb in printf
    style funcs.
  - For most errors (except for failed pre-condition), generate error
    messages within the error constructors. So that redundant definition
    of error messags is removed.

- Add tests for all error constructors, perun pkg has 100% coverage now.

- Move error assertions functions to perun-node/peruntest, as most of
  them are used in perun_test both session_test packages.

- Document the named errors returned by each of the API.

- Also, use upper case 'O' in timedOut in all the places.



##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

<!-- Bug Fix -->
<!-- Improvement -->
Implementation Task

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

Resolves #132.

#### Testing
<!-- Tell us how you have tested the changes. -->

Tests have been added in perun package for error constructors. This package now has 100% coverage.

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

1. 
2. 
3.  

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
