### PR TITLE
Add read-only chain backend to validate contracts

### DIFF
--- a/blockchain/ethereum/ethereumtest/chain.go
+++ b/blockchain/ethereum/ethereumtest/chain.go
@@ -53,10 +53,10 @@ type ChainBackendSetup struct {
 	AdjAddr, AssetAddr pwallet.Address
 }
 
-// NewChainBackendSetup returns a simulated contract backend with assetHolder and adjudicator contracts deployed.
+// NewSimChainBackendSetup returns a simulated contract backend with assetHolder and adjudicator contracts deployed.
 // It also generates the given number of accounts and funds them each with 10 ether.
 // and returns a test ChainBackend using the given randomness.
-func NewChainBackendSetup(t *testing.T, rng *rand.Rand, numAccs uint) *ChainBackendSetup {
+func NewSimChainBackendSetup(t *testing.T, rng *rand.Rand, numAccs uint) *ChainBackendSetup {
 	walletSetup := NewWalletSetupT(t, rng, numAccs)
 
 	cbEth := newSimContractBackend(t, walletSetup.Accs, walletSetup.Keystore)

--- a/perun.go
+++ b/perun.go
@@ -109,12 +109,12 @@ type Credential struct {
 	Password string
 }
 
-// ChainBackend wraps the methods required for instantiating and using components for
-// making on-chain transactions and reading on-chain values on a specific blockchain platform.
-// The timeout for on-chain transaction should be implemented by the corresponding backend. It is
-// up to the implementation to make the value user configurable.
+// ChainBackend wraps the methods required for deploy contracts, validating
+// them and instantiating funde, adjudicator instances.
 //
-// It defines methods for deploying contracts; validating deployed contracts and instantiating a funder, adjudicator.
+// The timeout for on-chain transaction should be implemented by the
+// corresponding backend. It is up to the implementation to make the value user
+// configurable.
 type ChainBackend interface {
 	DeployAdjudicator(onChainAddr pwallet.Address) (adjAddr pwallet.Address, _ error)
 	DeployAsset(adjAddr, onChainAddr pwallet.Address) (assetAddr pwallet.Address, _ error)
@@ -122,6 +122,16 @@ type ChainBackend interface {
 	ValidateAssetHolderETH(adjAddr, assetAddr pwallet.Address) error
 	NewFunder(assetAddr, onChainAddr pwallet.Address) pchannel.Funder
 	NewAdjudicator(adjAddr, receiverAddr pwallet.Address) pchannel.Adjudicator
+}
+
+// ROChainBackend wraps the methods required for validating contracts.
+//
+// The timeout for on-chain transaction should be implemented by the
+// corresponding backend. It is up to the implementation to make the value user
+// configurable.
+type ROChainBackend interface {
+	ValidateAdjudicator(adjAddr pwallet.Address) error
+	ValidateAssetHolderETH(adjAddr, assetAddr pwallet.Address) error
 }
 
 // WalletBackend wraps the methods for instantiating wallets and accounts that are specific to a blockchain platform.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->
- For validating contracts during node initialization, a read-only chain
  backend is needed, because node does not have credentials to
  initialize a full chain backend.

- Add a ROChainBackend interface that specifies only methods for
  validating the contracts.

-  Implement a constructor for ROChainBackend, where the transactor is
   set to nil. This is safe to use because only validation methods are
   exposed via this interface and those methods do not use the
   transactor.

##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

<!-- Bug Fix -->
<!-- Improvement -->
Implementation Task

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

Relates to #106.

#### Testing
<!-- Tell us how you have tested the changes. -->

Tests are added for validating contracts using read-only backend.

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

1. 
2. 
3.  

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
