### PR TITLE
Move contract validation from node to session init

### DIFF
--- a/node/node_integ_test.go
+++ b/node/node_integ_test.go
@@ -35,18 +35,15 @@ import (
 	"github.com/hyperledger-labs/perun-node/session/sessiontest"
 )
 
-var validConfig perun.NodeConfig
-
-func init() {
-	validConfig = nodetest.NewConfig()
-}
-
-// This NodeAPI instance will be set upon first happy test.
-// This will be used in the subsequent tests.
-var n perun.NodeAPI
-
 // Node can be initialized only once and hence run all the error cases before a happy test.
 func Test_Integ_New(t *testing.T) {
+	prng := rand.New(rand.NewSource(ethereumtest.RandSeedForTestAccs))
+	validConfig := nodetest.NewConfig()
+
+	// This NodeAPI instance will be set upon first happy test.
+	// This will be used in the subsequent tests.
+	var n perun.NodeAPI
+
 	// Deploy contracts.
 	ethereumtest.SetupContractsT(t, ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout)
 
@@ -55,20 +52,48 @@ func Test_Integ_New(t *testing.T) {
 		cfg.LogLevel = ""
 		_, err := node.New(cfg)
 		require.Error(t, err)
+		t.Log(err)
 	})
 
-	t.Run("err_invalid_adjudicator", func(t *testing.T) {
+	t.Run("err_invalid_adjudicator_address", func(t *testing.T) {
 		cfg := validConfig
 		cfg.Adjudicator = "invalid-addr"
 		_, err := node.New(cfg)
 		require.Error(t, err)
+		t.Log(err)
 	})
 
-	t.Run("err_invalid_asset", func(t *testing.T) {
+	t.Run("err_invalid_asset_address", func(t *testing.T) {
 		cfg := validConfig
 		cfg.Asset = "invalid-addr"
 		_, err := node.New(cfg)
 		require.Error(t, err)
+		t.Log(err)
+	})
+
+	t.Run("err_invalid_adjudicator_contract", func(t *testing.T) {
+		cfg := validConfig
+		cfg.Adjudicator = ethereumtest.NewRandomAddress(prng).String()
+		_, err := node.New(cfg)
+		require.Error(t, err)
+		t.Log(err)
+	})
+
+	t.Run("err_invalid_asset_contract", func(t *testing.T) {
+		cfg := validConfig
+		cfg.Asset = ethereumtest.NewRandomAddress(prng).String()
+		_, err := node.New(cfg)
+		require.Error(t, err)
+		t.Log(err)
+	})
+
+	t.Run("err_invalid_adjudicator_asset_contract", func(t *testing.T) {
+		cfg := validConfig
+		cfg.Adjudicator = ethereumtest.NewRandomAddress(prng).String()
+		cfg.Asset = ethereumtest.NewRandomAddress(prng).String()
+		_, err := node.New(cfg)
+		require.Error(t, err)
+		t.Log(err)
 	})
 
 	t.Run("happy", func(t *testing.T) {
@@ -93,7 +118,6 @@ func Test_Integ_New(t *testing.T) {
 	})
 
 	var sessionID string
-	prng := rand.New(rand.NewSource(ethereumtest.RandSeedForTestAccs))
 
 	t.Run("happy_OpenSession", func(t *testing.T) {
 		var err error
@@ -126,5 +150,6 @@ func Test_Integ_New(t *testing.T) {
 		sessionCfgFile := sessiontest.NewConfigFileT(t, sessionCfg)
 		_, _, err := n.OpenSession(sessionCfgFile)
 		require.Error(t, err)
+		t.Log(err)
 	})
 }

--- a/perun.go
+++ b/perun.go
@@ -151,14 +151,14 @@ type Currency interface {
 // NodeConfig represents the configurable parameters of a perun node.
 type NodeConfig struct {
 	// User configurable values.
-	LogLevel         string        // LogLevel represents the log level for the node and all derived loggers.
-	LogFile          string        // LogFile represents the file to write logs. Empty string represents stdout.
-	ChainURL         string        // Address of the default blockchain node used by the perun node.
-	Adjudicator      string        // Address of the default Adjudicator contract used by the perun node.
-	Asset            string        // Address of the default Asset Holder contract used by the perun node.
-	ChainConnTimeout time.Duration // Timeout for connecting to blockchain node.
-	OnChainTxTimeout time.Duration // Timeout to wait for confirmation of on-chain tx.
-	ResponseTimeout  time.Duration // Timeout to wait for a response from the peer / user.
+	LogLevel           string        // LogLevel represents the log level for the node and all derived loggers.
+	LogFile            string        // LogFile represents the file to write logs. Empty string represents stdout.
+	ChainURL           string        // URL of the blockchain node.
+	ChainID            int           // See session.chainconfig.
+	Asset, Adjudicator string        // Address of the Asset and Adjudicator contracts.
+	ChainConnTimeout   time.Duration // Timeout for connecting to blockchain node.
+	OnChainTxTimeout   time.Duration // Timeout to wait for confirmation of on-chain tx.
+	ResponseTimeout    time.Duration // Timeout to wait for a response from the peer / user.
 
 	// Hard coded values. See cmd/perunnode/run.go.
 	CommTypes            []string // Communication protocols supported by the node for off-chain communication.

--- a/session/config.go
+++ b/session/config.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
+	pwire "perun.network/go-perun/wire"
 )
 
 type (
@@ -29,19 +30,23 @@ type (
 	Config struct {
 		User UserConfig
 
-		IDProviderType     string        // Type of ID provider.
-		IDProviderURL      string        // URL for accessing the ID provider.
-		ChainURL           string        // URL of the blockchain node.
-		ChainID            int           // See client/config.go.
-		Asset, Adjudicator string        // Address of the Asset and Adjudicator contracts.
-		ChainConnTimeout   time.Duration // Timeout for connecting to blockchain node.
-		OnChainTxTimeout   time.Duration // Timeout to wait for confirmation of on-chain tx.
-		ResponseTimeout    time.Duration // Timeout to wait for a response from the peer / user.
+		IDProviderType   string        // Type of ID provider.
+		IDProviderURL    string        // URL for accessing the ID provider.
+		ChainURL         string        // URL of the blockchain node.
+		ChainID          int           // See chainconfig.
+		ChainConnTimeout time.Duration // Timeout for connecting to blockchain node.
+		OnChainTxTimeout time.Duration // Timeout to wait for confirmation of on-chain tx.
+		ResponseTimeout  time.Duration // Timeout to wait for a response from the peer / user.
 
 		DatabaseDir string // Path to directory containing persistence database.
 		// Timeout for re-establishing all open channels (if any) that was persisted during the
 		// previous running instance of the node.
 		PeerReconnTimeout time.Duration
+
+		// Address of the valid Asset and Adjudicator contracts.
+		// These values are set by the node and will not parsed from the user
+		// provided configuration.
+		Asset, Adjudicator pwire.Address `yaml:"-"`
 	}
 
 	// UserConfig defines the parameters required to configure a user.
@@ -68,7 +73,7 @@ type (
 
 	// clientConfig represents the configuration parameters for state channel client.
 	clientConfig struct {
-		Chain chainConfig
+		Chain ChainConfig
 
 		// Path to directory containing persistence database.
 		DatabaseDir string
@@ -77,12 +82,8 @@ type (
 		PeerReconnTimeout time.Duration
 	}
 
-	// chainConfig represents the configuration parameters for connecting to blockchain.
-	chainConfig struct {
-		// Addresses of on-chain contracts used for establishing state channel network.
-		Adjudicator string
-		Asset       string
-
+	// ChainConfig represents the configuration parameters for connecting to blockchain.
+	ChainConfig struct {
 		// URL for connecting to the blockchain node.
 		URL string
 		// ChainID is the unique identifier for different chains in the ethereum ecosystem.
@@ -91,6 +92,11 @@ type (
 		ConnTimeout time.Duration
 		// OnChainTxTimeout is the timeout to wait for a blockchain transaction to be finalized.
 		OnChainTxTimeout time.Duration
+
+		// Address of the valid Asset and Adjudicator contracts.
+		// These values are set by the node and will not parsed from the user
+		// provided configuration.
+		Asset, Adjudicator pwire.Address `yaml:"-"`
 	}
 )
 

--- a/session/config_test.go
+++ b/session/config_test.go
@@ -52,8 +52,6 @@ var (
 		IDProviderType: "local",
 		IDProviderURL:  "./test-idprovider.yaml",
 		ChainURL:       "ws://127.0.0.1:8545",
-		Asset:          "0x5992089d61cE79B6CF90506F70DD42B8E42FB21d",
-		Adjudicator:    "0x9daEdAcb21dce86Af8604Ba1A1D7F9BFE55ddd63",
 		DatabaseDir:    "./test-db",
 	}
 )

--- a/session/export_test.go
+++ b/session/export_test.go
@@ -47,11 +47,6 @@ func NewSessionForTest(cfg Config, isOpen bool, chClient ChClient) (*Session, er
 		return nil, apiErr
 	}
 
-	chAsset, err := walletBackend.ParseAddr(cfg.Asset)
-	if err != nil {
-		return nil, err
-	}
-
 	idProvider, apiErr := initIDProvider(cfg.IDProviderType, cfg.IDProviderURL, walletBackend, user.PeerID)
 	if apiErr != nil {
 		return nil, apiErr
@@ -70,7 +65,7 @@ func NewSessionForTest(cfg Config, isOpen bool, chClient ChClient) (*Session, er
 		chainURL:             cfg.ChainURL,
 		timeoutCfg:           timeoutCfg,
 		user:                 user,
-		chAsset:              chAsset,
+		chAsset:              cfg.Asset,
 		chClient:             chClient,
 		idProvider:           idProvider,
 		chs:                  newChRegistry(initialChRegistrySize),

--- a/session/session.go
+++ b/session/session.go
@@ -164,17 +164,13 @@ func New(cfg Config) (*Session, perun.APIError) {
 		return nil, perun.NewAPIErrInvalidConfig(ErrUnsupportedType, "commType", cfg.User.CommType)
 	}
 	commBackend := tcp.NewTCPBackend(tcptest.DialerTimeout)
-	chAsset, err := walletBackend.ParseAddr(cfg.Asset)
-	if err != nil {
-		return nil, perun.NewAPIErrInvalidConfig(err, "asset", cfg.Asset)
-	}
 	idProvider, apiErr := initIDProvider(cfg.IDProviderType, cfg.IDProviderURL, walletBackend, user.PeerID)
 	if apiErr != nil {
 		return nil, apiErr
 	}
 
 	chClientCfg := clientConfig{
-		Chain: chainConfig{
+		Chain: ChainConfig{
 			Adjudicator:      cfg.Adjudicator,
 			Asset:            cfg.Asset,
 			URL:              cfg.ChainURL,
@@ -202,13 +198,13 @@ func New(cfg Config) (*Session, perun.APIError) {
 		chainURL:             cfg.ChainURL,
 		timeoutCfg:           timeoutCfg,
 		user:                 user,
-		chAsset:              chAsset,
+		chAsset:              cfg.Asset,
 		chClient:             chClient,
 		idProvider:           idProvider,
 		chs:                  newChRegistry(initialChRegistrySize),
 		chProposalResponders: make(map[string]chProposalResponderEntry),
 	}
-	err = sess.chClient.RestoreChs(sess.handleRestoredCh)
+	err := sess.chClient.RestoreChs(sess.handleRestoredCh)
 	if err != nil {
 		err = errors.WithMessage(err, "restoring channels")
 		return nil, perun.NewAPIErrInvalidConfig(err, "databaseDir", cfg.DatabaseDir)

--- a/session/session_integ_test.go
+++ b/session/session_integ_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/perun-node"
-	"github.com/hyperledger-labs/perun-node/blockchain"
 	"github.com/hyperledger-labs/perun-node/blockchain/ethereum/ethereumtest"
 	"github.com/hyperledger-labs/perun-node/comm/tcp"
 	"github.com/hyperledger-labs/perun-node/idprovider/idprovidertest"
@@ -142,67 +141,6 @@ func Test_Integ_New(t *testing.T) {
 		require.Error(t, err)
 		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
 		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "offChainWallet", wantValue)
-	})
-
-	t.Run("invalidConfig_adjudicator", func(t *testing.T) {
-		cfgCopy := cfg
-		cfgCopy.DatabaseDir = newDatabaseDir(t)
-		cfgCopy.Adjudicator = "invalid-addr"
-		_, err := session.New(cfgCopy)
-		require.Error(t, err)
-		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "adjudicator", cfgCopy.Adjudicator)
-	})
-	t.Run("invalidConfig_asset", func(t *testing.T) {
-		cfgCopy := cfg
-		cfgCopy.DatabaseDir = newDatabaseDir(t)
-		cfgCopy.Asset = "invalid-addr"
-		_, err := session.New(cfgCopy)
-		require.Error(t, err)
-		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidConfig, "")
-		peruntest.AssertErrInfoInvalidConfig(t, err.AddInfo(), "asset", cfgCopy.Asset)
-	})
-	t.Run("invalid_adjudicator_contract", func(t *testing.T) {
-		cfgCopy := cfg
-		cfgCopy.DatabaseDir = newDatabaseDir(t)
-		cfgCopy.Adjudicator = ethereumtest.NewRandomAddress(prng).String()
-		_, err := session.New(cfgCopy)
-		require.Error(t, err)
-		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidContracts, "")
-		// Both contracts will be returned as invalid because, the asset holder
-		// validation function in go-perun passes only if both adjudicator and
-		// asset holder contracts are valid.
-		wantContractsInfo := []perun.ContractErrInfo{
-			{Name: string(blockchain.Adjudicator), Address: cfgCopy.Adjudicator},
-			{Name: string(blockchain.AssetHolderETH), Address: cfgCopy.Asset},
-		}
-		peruntest.AssertErrInfoInvalidContracts(t, err.AddInfo(), wantContractsInfo)
-	})
-	t.Run("invalid_asset_contract", func(t *testing.T) {
-		cfgCopy := cfg
-		cfgCopy.DatabaseDir = newDatabaseDir(t)
-		cfgCopy.Asset = ethereumtest.NewRandomAddress(prng).String()
-		_, err := session.New(cfgCopy)
-		require.Error(t, err)
-		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidContracts, "")
-		wantContractsInfo := []perun.ContractErrInfo{
-			{Name: string(blockchain.AssetHolderETH), Address: cfgCopy.Asset},
-		}
-		peruntest.AssertErrInfoInvalidContracts(t, err.AddInfo(), wantContractsInfo)
-	})
-	t.Run("invalid_adjudicator_asset_contract", func(t *testing.T) {
-		cfgCopy := cfg
-		cfgCopy.DatabaseDir = newDatabaseDir(t)
-		cfgCopy.Adjudicator = ethereumtest.NewRandomAddress(prng).String()
-		cfgCopy.Asset = ethereumtest.NewRandomAddress(prng).String()
-		_, err := session.New(cfgCopy)
-		require.Error(t, err)
-		peruntest.AssertAPIError(t, err, perun.ClientError, perun.ErrInvalidContracts, "")
-		wantContractsInfo := []perun.ContractErrInfo{
-			{Name: string(blockchain.Adjudicator), Address: cfgCopy.Adjudicator},
-			{Name: string(blockchain.AssetHolderETH), Address: cfgCopy.Asset},
-		}
-		peruntest.AssertErrInfoInvalidContracts(t, err.AddInfo(), wantContractsInfo)
 	})
 
 	t.Run("invalidConfig_commType", func(t *testing.T) {

--- a/session/sessiontest/config.go
+++ b/session/sessiontest/config.go
@@ -122,8 +122,6 @@ func NewConfig(rng *rand.Rand, peerIDs ...perun.PeerID) (session.Config, error) 
 		User:              userCfg,
 		ChainURL:          ethereumtest.ChainURL,
 		ChainID:           ethereumtest.ChainID,
-		Adjudicator:       adjudicator.String(),
-		Asset:             asset.String(),
 		ChainConnTimeout:  ethereumtest.ChainConnTimeout,
 		ResponseTimeout:   ResponseTimeout,
 		OnChainTxTimeout:  ethereumtest.OnChainTxTimeout,
@@ -132,6 +130,9 @@ func NewConfig(rng *rand.Rand, peerIDs ...perun.PeerID) (session.Config, error) 
 
 		IDProviderType: "local",
 		IDProviderURL:  idProviderURL,
+
+		Adjudicator: adjudicator,
+		Asset:       asset,
 	}, nil
 }
 

--- a/testdata/session/valid.yaml
+++ b/testdata/session/valid.yaml
@@ -15,7 +15,5 @@ user:
 idProviderType: local
 idProviderURL: ./test-idprovider.yaml
 chainURL: ws://127.0.0.1:8545  
-asset: 0x5992089d61cE79B6CF90506F70DD42B8E42FB21d
-adjudicator: 0x9daEdAcb21dce86Af8604Ba1A1D7F9BFE55ddd63
     
 databaseDir: ./test-db 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->

- Contracts are validated during node initialization using a read-only
  blockchain backend. Validated addresses are then stored in a registry
  and passed on to the session.

- Since valid contract addresses are provided by the node, use the
  addresses without validation in session init. Also, remove the tests
  related to invalid contracts for OpenSession and updates its doc
  comments to remove InvalidContracts Error.

- Remove the option for user to provide the addresses in session config.
  Also, remove the contract addresses from session config template in
  testdata.


##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

<!-- Bug Fix -->
<!-- Improvement -->
Implementation Task

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

Resolves #106.
#### Testing
<!-- Tell us how you have tested the changes. -->
Added tests for contract validation in node init. Tested `perunnodetui` and perunnodecli`.

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

1. 
2. 
3.  

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
