### PR TITLE
Impl contract registry & use it in node init

### DIFF
--- a/api/grpc/server_integ_test.go
+++ b/api/grpc/server_integ_test.go
@@ -69,7 +69,7 @@ func StartServer(t *testing.T, nodeCfg perun.NodeConfig, grpcPort string) {
 
 func Test_Integ_Role(t *testing.T) {
 	// Deploy contracts on blockchain.
-	ethereumtest.SetupContractsT(t, ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout)
+	ethereumtest.SetupContractsT(t, ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout, false)
 
 	// Run server in a go routine.
 	StartServer(t, nodetest.NewConfig(), grpcPort)

--- a/app/payment/payment_test.go
+++ b/app/payment/payment_test.go
@@ -64,9 +64,9 @@ func Test_Integ_PaymentAPI(t *testing.T) {
 	chainID := ethereumtest.ChainID
 	chainURL := ethereumtest.ChainURL
 	onChainTxTimeout := ethereumtest.OnChainTxTimeout
-	adjudicator, assetETH, err := ethereumtest.SetupContracts(chainURL, chainID, onChainTxTimeout)
+	contracts, err := ethereumtest.SetupContracts(chainURL, chainID, onChainTxTimeout, false)
 	handleError(err, "deploying contracts")
-	fmt.Printf("contracts deployed at: adjudicator:%s, asset ETH:%s\n", adjudicator, assetETH)
+	fmt.Printf("contracts deployed at: adjudicator:%s, asset ETH:%s\n", contracts.Adjudicator(), contracts.AssetETH())
 
 	prng := rand.New(rand.NewSource(ethereumtest.RandSeedForTestAccs))
 
@@ -81,11 +81,11 @@ func Test_Integ_PaymentAPI(t *testing.T) {
 	// *******************************************************
 	fmt.Println("\n=== Setup: Initialize sessions and cross register peer IDs ===")
 
-	aliceSess, err := session.New(aliceCfg, currencies)
+	aliceSess, err := session.New(aliceCfg, currencies, contracts)
 	handleError(err, "alice: initializing session")
 	fmt.Printf("alice: initialized session, session ID: %s\n", aliceSess.ID())
 
-	bobSess, err := session.New(bobCfg, currencies)
+	bobSess, err := session.New(bobCfg, currencies, contracts)
 	handleError(err, "initializing session for bob")
 	fmt.Printf("bob: initialized session, session ID: %s\n\n", bobSess.ID())
 

--- a/blockchain/errors.go
+++ b/blockchain/errors.go
@@ -22,9 +22,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ContractName identifies specific type of contract.
-type ContractName string
-
 // Enumeration of contract names for perun node.
 const (
 	Adjudicator = "adjudicator"
@@ -41,7 +38,7 @@ type InvalidContractError struct {
 
 // Error implements error interface.
 func (e InvalidContractError) Error() string {
-	return fmt.Sprintf("invalid %s contract at address %s: %v", e.Name, e.Address, e.err)
+	return fmt.Sprintf("invalid asset %s contract at address %s: %v", e.Name, e.Address, e.err)
 }
 
 // Unwrap returns the original error.
@@ -50,10 +47,30 @@ func (e InvalidContractError) Unwrap() error {
 }
 
 // NewInvalidContractError constructs and returns an InvalidContractError.
-func NewInvalidContractError(name string, address string, err error) error {
+func NewInvalidContractError(name, address string, err error) error {
 	return errors.WithStack(InvalidContractError{
 		Name:    name,
 		Address: address,
 		err:     err,
+	})
+}
+
+// AssetERC20RegisteredError indicates that an asset contract for the given
+// ERC20 token was already registered.
+type AssetERC20RegisteredError struct {
+	Asset  string
+	Symbol string
+}
+
+// Error implements error interface.
+func (e AssetERC20RegisteredError) Error() string {
+	return fmt.Sprintf("already registered asset (%s) for the symbol %s", e.Asset, e.Symbol)
+}
+
+// NewAssetERC20RegisteredError constructs and returns an AssetERC20RegisteredError.
+func NewAssetERC20RegisteredError(asset, symbol string) error {
+	return errors.WithStack(AssetERC20RegisteredError{
+		Asset:  asset,
+		Symbol: symbol,
 	})
 }

--- a/blockchain/errors_test.go
+++ b/blockchain/errors_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository at
+// https://github.com/hyperledger-labs/perun-node
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockchain_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/perun-node/blockchain"
+)
+
+func Test_NewInvalidContractError(t *testing.T) {
+	name := "some-name"
+	address := "some-address"
+	err := assert.AnError
+
+	gotErr := blockchain.NewInvalidContractError(name, address, err)
+	require.Error(t, gotErr)
+
+	invalidContractErr := blockchain.InvalidContractError{}
+	require.True(t, errors.As(gotErr, &invalidContractErr))
+
+	assert.Equal(t, name, invalidContractErr.Name)
+	assert.Equal(t, address, invalidContractErr.Address)
+	assert.True(t, errors.Is(gotErr, err), "should return the underlying error for comparison")
+}
+
+func Test_NewAssetERC20RegisteredError(t *testing.T) {
+	asset := "some-asset"
+	symbol := "some-symbol"
+
+	gotErr := blockchain.NewAssetERC20RegisteredError(asset, symbol)
+	require.Error(t, gotErr)
+
+	assetERC20RegisteredError := blockchain.AssetERC20RegisteredError{}
+	require.True(t, errors.As(gotErr, &assetERC20RegisteredError))
+
+	assert.Equal(t, asset, assetERC20RegisteredError.Asset)
+	assert.Equal(t, symbol, assetERC20RegisteredError.Symbol)
+}

--- a/blockchain/ethereum/internal/chain.go
+++ b/blockchain/ethereum/internal/chain.go
@@ -134,14 +134,12 @@ func (cb *ChainBackend) ValidateAssetERC20(adj, tokenERC20, assetERC20 pwallet.A
 	if err != nil {
 		return "", 0, errors.WithMessage(err, "reading symbol and decimal values from token contract")
 	}
-
 	// Though integrity of adjudicator is implicitly checked by ValidateAssetHolderERC20,
 	// we do it before that call to identify this type of error.
 	err = pethchannel.ValidateAdjudicator(ctx, *cb.Cb, pethwallet.AsEthAddr(adj))
 	if pethchannel.IsErrInvalidContractCode(err) {
 		return "", 0, blockchain.NewInvalidContractError(blockchain.Adjudicator, adj.String(), err)
 	}
-
 	err = pethchannel.ValidateAssetHolderERC20(ctx, *cb.Cb,
 		pethwallet.AsEthAddr(assetERC20), pethwallet.AsEthAddr(adj), pethwallet.AsEthAddr(tokenERC20))
 	if err != nil && pethchannel.IsErrInvalidContractCode(err) {

--- a/blockchain/ethereum/internal/chain_integ_test.go
+++ b/blockchain/ethereum/internal/chain_integ_test.go
@@ -36,14 +36,14 @@ func Test_ROChainBackend_ValidateAdjudicator(t *testing.T) {
 	// use a real chain backend instead of simulated because, multiple connections are to be made:
 	// 1. With a ChainBackend for deploying contracts.
 	// 2. Use a ROChainbackend for validating contracts.
-	adjudicator, _ := ethereumtest.SetupContractsT(t,
-		ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout)
+	contracts := ethereumtest.SetupContractsT(t,
+		ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout, false)
 	roChainBackend, err := ethereum.NewROChainBackend(
 		ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.ChainConnTimeout)
 	require.NoError(t, err)
 
 	t.Run("happy", func(t *testing.T) {
-		assert.NoError(t, roChainBackend.ValidateAdjudicator(adjudicator))
+		assert.NoError(t, roChainBackend.ValidateAdjudicator(contracts.Adjudicator()))
 	})
 
 	t.Run("invalid_adjudicator", func(t *testing.T) {
@@ -64,19 +64,19 @@ func Test_Integ_ROChainBackend_ValidateAssetETH(t *testing.T) {
 	// use a real chain backend instead of simulated because, multiple connections are to be made:
 	// 1. With a ChainBackend for deploying contracts.
 	// 2. Use a ROChainbackend for validating contracts.
-	adjudicator, assetETH := ethereumtest.SetupContractsT(t,
-		ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout)
+	contracts := ethereumtest.SetupContractsT(t,
+		ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout, false)
 	roChainBackend, err := ethereum.NewROChainBackend(
 		ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.ChainConnTimeout)
 	require.NoError(t, err)
 
 	t.Run("happy", func(t *testing.T) {
-		assert.NoError(t, roChainBackend.ValidateAdjudicator(adjudicator))
-		assert.NoError(t, roChainBackend.ValidateAssetETH(adjudicator, assetETH))
+		assert.NoError(t, roChainBackend.ValidateAdjudicator(contracts.Adjudicator()))
+		assert.NoError(t, roChainBackend.ValidateAssetETH(contracts.Adjudicator(), contracts.AssetETH()))
 	})
 	t.Run("invalid_adjudicator", func(t *testing.T) {
 		randomAddr1 := ethereumtest.NewRandomAddress(rng)
-		err := roChainBackend.ValidateAssetETH(randomAddr1, assetETH)
+		err := roChainBackend.ValidateAssetETH(randomAddr1, contracts.AssetETH())
 
 		require.Error(t, err)
 		invalidContractError := blockchain.InvalidContractError{}
@@ -87,7 +87,7 @@ func Test_Integ_ROChainBackend_ValidateAssetETH(t *testing.T) {
 	})
 	t.Run("invalid_assetHolderETH", func(t *testing.T) {
 		randomAddr1 := ethereumtest.NewRandomAddress(rng)
-		err := roChainBackend.ValidateAssetETH(adjudicator, randomAddr1)
+		err := roChainBackend.ValidateAssetETH(contracts.Adjudicator(), randomAddr1)
 
 		require.Error(t, err)
 		invalidContractError := blockchain.InvalidContractError{}

--- a/blockchain/ethereum/registry.go
+++ b/blockchain/ethereum/registry.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2021 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository at
+// https://github.com/hyperledger-labs/perun-node
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethereum
+
+import (
+	"sync"
+
+	pwallet "perun.network/go-perun/wallet"
+
+	"github.com/hyperledger-labs/perun-node"
+	"github.com/hyperledger-labs/perun-node/blockchain"
+)
+
+// Use a slice to keep track of registered symbols because iterating over map
+// to retrieve the symbols each time will result in different ordering of
+// symbols in the list.
+type contractRegistry struct {
+	mtx         sync.RWMutex
+	chain       perun.ROChainBackend // read-only chain backend for validating contracts.
+	adjudicator pwallet.Address
+	assetETH    pwallet.Address
+	assets      map[string]pwallet.Address
+}
+
+// NewContractRegistry initializes a contract registry and sets the adjudicator
+// and asset ETH contract addresses.
+//
+// If it returns an error, it could be one of the following:
+// - InvalidContractError if the contract at given adjudicator or asset ETH
+// address is invalid.
+// - Standard error if the adjudicator address in the asset ETH contract does not
+// match the passed value.
+func NewContractRegistry(chain perun.ROChainBackend, adjudicator, assetETH pwallet.Address) (
+	perun.ContractRegistry, error) {
+	err := chain.ValidateAdjudicator(adjudicator)
+	if err != nil {
+		return nil, err
+	}
+	err = chain.ValidateAssetETH(adjudicator, assetETH)
+	if err != nil {
+		return nil, err
+	}
+
+	r := contractRegistry{
+		chain:       chain,
+		adjudicator: adjudicator,
+		assetETH:    assetETH,
+		assets:      make(map[string]pwallet.Address),
+	}
+	return &r, nil
+}
+
+// RegisterAsset registers the currency symbol and the asset contract in the
+// registry.
+//
+// If it returns an error, it could be one of the following:
+// - AssetERC20RegisteredError if an the same asset contract was already
+// registered for another symbol or if another asset contract is registered for
+// the symbol of this token contract. For this, symbol is read from blockchain.
+// - InvalidContractError if the contract at given asset address is invalid.
+// - Standard error if the symbol & decimals could not be read from the
+// blockchain or if the token address in the asset contract does not match the
+// passed value.
+func (r *contractRegistry) RegisterAssetERC20(token, asset pwallet.Address) (
+	string, uint8, error) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	if symbol, found := r.isAssetRegistered(asset); found {
+		return "", 0, blockchain.NewAssetERC20RegisteredError(asset.String(), symbol)
+	}
+
+	symbol, maxDecimals, err := r.chain.ValidateAssetERC20(r.adjudicator, token, asset)
+	if err != nil {
+		return "", 0, err
+	}
+
+	if alreadyRegisteredAsset, found := r.isSymbolRegistered(symbol); found {
+		return "", 0, blockchain.NewAssetERC20RegisteredError(alreadyRegisteredAsset.String(), symbol)
+	}
+
+	r.assets[symbol] = asset
+	return symbol, maxDecimals, nil
+}
+
+// Adjudicator returns adjudicator contract address.
+func (r *contractRegistry) Adjudicator() pwallet.Address {
+	r.mtx.RLock()
+	adjudicator := r.adjudicator
+	r.mtx.RUnlock()
+	return adjudicator
+}
+
+// AssetETH returns asset ETH contract address.
+func (r *contractRegistry) AssetETH() pwallet.Address {
+	r.mtx.RLock()
+	assetETH := r.assetETH
+	r.mtx.RUnlock()
+	return assetETH
+}
+
+// Assets returns a list of all the asset contract addresses
+// registered in this module with the addresses in string format.
+func (r *contractRegistry) Assets() map[string]string {
+	r.mtx.RLock()
+	assetsCopy := make(map[string]string, len(r.assets))
+	assetsCopy["ETH"] = r.assetETH.String()
+	for symbol, asset := range r.assets {
+		assetsCopy[symbol] = asset.String()
+	}
+	r.mtx.RUnlock()
+	return assetsCopy
+}
+
+// Asset returns asset contract address for the given symbol.
+func (r *contractRegistry) Asset(symbol string) (asset pwallet.Address, found bool) {
+	r.mtx.RLock()
+	asset, found = r.isSymbolRegistered(symbol)
+	r.mtx.RUnlock()
+	return asset, found
+}
+
+// Symbol returns symbol for the given asset contract address.
+func (r *contractRegistry) Symbol(asset pwallet.Address) (symbol string, found bool) {
+	r.mtx.RLock()
+	symbol, found = r.isAssetRegistered(asset)
+	r.mtx.RUnlock()
+	return symbol, found
+}
+
+func (r *contractRegistry) isSymbolRegistered(symbol string) (asset pwallet.Address, found bool) {
+	asset, found = r.assets[symbol]
+	return asset, found && asset != nil
+}
+
+func (r *contractRegistry) isAssetRegistered(asset pwallet.Address) (symbol string, found bool) {
+	for symbol, gotAsset := range r.assets {
+		if gotAsset.Equals(asset) {
+			return symbol, true
+		}
+	}
+	return "", false
+}

--- a/blockchain/ethereum/registry_test.go
+++ b/blockchain/ethereum/registry_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2021 - for information on the respective copyright owner
+// see the NOTICE file and/or the repository at
+// https://github.com/hyperledger-labs/perun-node
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethereum_test
+
+import (
+	"errors"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pwallet "perun.network/go-perun/wallet"
+
+	"github.com/hyperledger-labs/perun-node/blockchain"
+	"github.com/hyperledger-labs/perun-node/blockchain/ethereum"
+	"github.com/hyperledger-labs/perun-node/blockchain/ethereum/ethereumtest"
+	"github.com/hyperledger-labs/perun-node/currency"
+)
+
+func Test_ContractRegistry_Adjudicator_AssetETH(t *testing.T) {
+	t.Run("happy", func(t *testing.T) {
+		// Each case not organized as sub-tests because order of execution is to be
+		// maintained.
+
+		rng := rand.New(rand.NewSource(rand.Int63()))
+		setup := ethereumtest.NewSimChainBackendSetup(t, rng, 2)
+
+		// happy/NewContractRegistry.
+		r, err := ethereum.NewContractRegistry(setup.ChainBackend, setup.Adjudicator, setup.AssetETH)
+		require.NoError(t, err)
+		require.NotNil(t, r)
+
+		// happy/registry.adjudicator.
+		gotAdjudicator := r.Adjudicator()
+		assert.NotNil(t, gotAdjudicator)
+		assert.Equal(t, setup.Adjudicator, gotAdjudicator)
+
+		// happy/registry.asset.
+		gotAssetETH := r.AssetETH()
+		assert.Equal(t, setup.AssetETH, gotAssetETH)
+
+		// happy/registry.assets.
+		assets := r.Assets()
+		require.Len(t, assets, 1, "should contain only one asset: ETH after init")
+		require.Equal(t, setup.AssetETH.String(), assets[currency.ETHSymbol])
+	})
+
+	t.Run("invalid_adjudicator", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(rand.Int63()))
+		setup := ethereumtest.NewSimChainBackendSetup(t, rng, 2)
+		randomAddr1 := ethereumtest.NewRandomAddress(rng)
+
+		_, err := ethereum.NewContractRegistry(setup.ChainBackend, randomAddr1, setup.AssetETH)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid_asset", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(rand.Int63()))
+		setup := ethereumtest.NewSimChainBackendSetup(t, rng, 2)
+		randomAddr1 := ethereumtest.NewRandomAddress(rng)
+
+		_, err := ethereum.NewContractRegistry(setup.ChainBackend, setup.Adjudicator, randomAddr1)
+		require.Error(t, err)
+	})
+}
+
+func Test_ContractRegistry_ERC20(t *testing.T) {
+	t.Run("happy", func(t *testing.T) {
+		// Each case not organized as sub-tests because order of execution is to be
+		// maintained.
+
+		rng := rand.New(rand.NewSource(rand.Int63()))
+		setup := ethereumtest.NewSimChainBackendSetup(t, rng, 2)
+		perunSymbol := "PRN"
+
+		// happy/NewContractRegistry
+		r, err := ethereum.NewContractRegistry(setup.ChainBackend, setup.Adjudicator, setup.AssetETH)
+		require.NoError(t, err)
+		require.NotNil(t, r)
+
+		// happy/registry.Asset.
+		_, found := r.Asset(perunSymbol)
+		assert.False(t, found, "No ERC20 tokens should be registered during init")
+
+		var tokenERC20, assetERC20 pwallet.Address
+		var symbol string
+		require.Len(t, setup.AssetERC20s, 1, "setup should contain only one erc20 asset info")
+		for tokenERC20, assetERC20 = range setup.AssetERC20s {
+			symbol, _, err = r.RegisterAssetERC20(tokenERC20, assetERC20)
+			require.NoError(t, err)
+		}
+
+		// happy/registry.Asset.
+		gotAsset, found := r.Asset(perunSymbol)
+		assert.True(t, found, "No ERC20 tokens should be registered during init")
+		require.True(t, assetERC20.Equals(gotAsset))
+
+		// happy/registry.Symbol.
+		gotSymbol, found := r.Symbol(assetERC20)
+		assert.True(t, found, "No ERC20 tokens should be registered during init")
+		require.Equal(t, perunSymbol, gotSymbol)
+
+		// happy/registry.Assets.
+		assets := r.Assets()
+		require.Len(t, assets, 2, "should contain only two assets: ETH, PRN")
+		require.Equal(t, setup.AssetETH.String(), assets[currency.ETHSymbol])
+		require.Equal(t, assetERC20.String(), assets[symbol])
+	})
+
+	t.Run("invalid_tokenERC20", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(rand.Int63()))
+		setup := ethereumtest.NewSimChainBackendSetup(t, rng, 2)
+		randomAddr1 := ethereumtest.NewRandomAddress(rng)
+
+		r, err := ethereum.NewContractRegistry(setup.ChainBackend, setup.Adjudicator, setup.AssetETH)
+		require.NoError(t, err)
+		require.NotNil(t, r)
+
+		for _, assetERC20 := range setup.AssetERC20s {
+			_, _, err = r.RegisterAssetERC20(randomAddr1, assetERC20)
+			require.Error(t, err)
+
+			invalidContractErr := blockchain.InvalidContractError{}
+			assert.False(t, errors.As(err, &invalidContractErr))
+		}
+	})
+
+	t.Run("invalid_assetERC20", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(rand.Int63()))
+		setup := ethereumtest.NewSimChainBackendSetup(t, rng, 2)
+		perunSymbol := "PRN"
+		randomAddr1 := ethereumtest.NewRandomAddress(rng)
+
+		r, err := ethereum.NewContractRegistry(setup.ChainBackend, setup.Adjudicator, setup.AssetETH)
+		require.NoError(t, err)
+		require.NotNil(t, r)
+
+		for tokenERC20 := range setup.AssetERC20s {
+			_, _, err = r.RegisterAssetERC20(tokenERC20, randomAddr1)
+			require.Error(t, err)
+
+			invalidContractErr := blockchain.InvalidContractError{}
+			assert.True(t, errors.As(err, &invalidContractErr))
+			assert.Equal(t, perunSymbol, invalidContractErr.Name)
+		}
+	})
+
+	t.Run("re-register", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(rand.Int63()))
+		setup := ethereumtest.NewSimChainBackendSetup(t, rng, 2)
+		perunSymbol := "PRN"
+
+		r, err := ethereum.NewContractRegistry(setup.ChainBackend, setup.Adjudicator, setup.AssetETH)
+		require.NoError(t, err)
+		require.NotNil(t, r)
+
+		require.Len(t, setup.AssetERC20s, 1, "setup should contain only one erc20 asset info")
+		var tokenERC20, assetERC20 pwallet.Address
+		var symbol string
+		for tokenERC20, assetERC20 = range setup.AssetERC20s {
+			// Register the token once.
+			symbol, _, err = r.RegisterAssetERC20(tokenERC20, assetERC20)
+			require.NoError(t, err)
+			assert.Equal(t, perunSymbol, symbol)
+		}
+		t.Run("sameAsset_sameToken", func(t *testing.T) {
+			_, _, err = r.RegisterAssetERC20(tokenERC20, assetERC20)
+			require.Error(t, err)
+			assetERC20RegisteredError := blockchain.AssetERC20RegisteredError{}
+			require.True(t, errors.As(err, &assetERC20RegisteredError))
+			assert.Equal(t, assetERC20.String(), assetERC20RegisteredError.Asset)
+			assert.Equal(t, perunSymbol, assetERC20RegisteredError.Symbol)
+		})
+		// TODO: This test requires a second erc20 sample contract with a different symbol.
+		// Add the test after another erc20 contract is added.
+		// t.Run("sameAsset_differentToken", func(t *testing.T) {
+		// })
+	})
+}

--- a/cmd/perunnode/generate.go
+++ b/cmd/perunnode/generate.go
@@ -127,7 +127,7 @@ func generateNodeConfig() error {
 		return errors.New("file exists - " + nodeConfigFile)
 	}
 	nodeCfg := nodetest.NewConfig()
-	adjudicator, assetETH := ethereumtest.ContractAddrs()
+	adjudicator, assetETH, _ := ethereumtest.ContractAddrs()
 	nodeCfg.Adjudicator = adjudicator.String()
 	nodeCfg.AssetETH = assetETH.String()
 	// Create file in temp dir.

--- a/cmd/perunnodecli/chain.go
+++ b/cmd/perunnodecli/chain.go
@@ -128,14 +128,13 @@ func deployPerunContractsFn(c *ishell.Context) {
 		return
 	}
 
-	chainID := ethereumtest.ChainID
-	adjudicator, assetETH, err := ethereumtest.SetupContracts(chainAddr, chainID, ethereumtest.OnChainTxTimeout)
+	contracts, err := ethereumtest.SetupContracts(chainAddr, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout, false)
 	if err != nil {
 		c.Printf("%s\n\n", redf("Error deploying contracts: %v", err))
 		return
 	}
 	c.Printf("%s\n\n", greenf("Contracts deployed successfully.\nAdjudicator address: %v\nAsset ETH address: %v\n",
-		adjudicator, assetETH))
+		contracts.Adjudicator(), contracts.AssetETH()))
 }
 
 func getOnChainBalanceFn(c *ishell.Context) {

--- a/cmd/perunnodetui/main.go
+++ b/cmd/perunnodetui/main.go
@@ -153,11 +153,12 @@ func parseFlags() (bool, string) {
 }
 
 func deployContractsIfRequested(requested bool) {
-	if requested {
-		_, _, err := ethereumtest.SetupContracts(defaultChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout)
-		if err != nil {
-			panic(err)
-		}
+	if !requested {
+		return
+	}
+	_, err := ethereumtest.SetupContracts(defaultChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout, false)
+	if err != nil {
+		panic(err)
 	}
 }
 

--- a/node/node_integ_test.go
+++ b/node/node_integ_test.go
@@ -45,7 +45,7 @@ func Test_Integ_New(t *testing.T) {
 	var n perun.NodeAPI
 
 	// Deploy contracts.
-	ethereumtest.SetupContractsT(t, ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout)
+	ethereumtest.SetupContractsT(t, ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout, false)
 
 	t.Run("err_invalid_log_level", func(t *testing.T) {
 		cfg := validConfig

--- a/node/nodetest/config.go
+++ b/node/nodetest/config.go
@@ -26,14 +26,21 @@ import (
 //
 // Contract addressses and chain parameters are fetched from the ethereumtest package.
 func NewConfig() perun.NodeConfig {
-	adjudicator, assetETH := ethereumtest.ContractAddrs()
+	adjudicator, assetETH, assetERC20s := ethereumtest.ContractAddrs()
+
+	assetERC20sString := make(map[string]string)
+	for tokenERC20, assetERC20 := range assetERC20s {
+		assetERC20sString[tokenERC20.String()] = assetERC20.String()
+	}
 
 	return perun.NodeConfig{
 		LogFile:              "",
 		LogLevel:             "debug",
 		ChainURL:             ethereumtest.ChainURL,
+		ChainID:              ethereumtest.ChainID,
 		Adjudicator:          adjudicator.String(),
 		AssetETH:             assetETH.String(),
+		AssetERC20s:          assetERC20sString,
 		CommTypes:            []string{"tcp"},
 		IDProviderTypes:      []string{"local"},
 		CurrencyInterpreters: []string{"ETH"},

--- a/perun.go
+++ b/perun.go
@@ -167,18 +167,35 @@ type ROCurrencyRegistry interface {
 	Symbols() []string
 }
 
+// ContractRegistry provides an interface to register and retrieve adjudicator
+// and asset contracts.
+type ContractRegistry interface {
+	ROContractRegistry
+	RegisterAssetERC20(token, asset pwallet.Address) (symbol string, maxDecimals uint8, _ error)
+}
+
+// ROContractRegistry provides an interface to retrieve contracts.
+type ROContractRegistry interface {
+	Adjudicator() pwallet.Address
+	AssetETH() pwallet.Address
+	Asset(symbol string) (asset pwallet.Address, found bool)
+	Symbol(asset pwallet.Address) (symbol string, found bool)
+	Assets() map[string]string
+}
+
 // NodeConfig represents the configurable parameters of a perun node.
 type NodeConfig struct {
 	// User configurable values.
-	LogLevel         string        // LogLevel represents the log level for the node and all derived loggers.
-	LogFile          string        // LogFile represents the file to write logs. Empty string represents stdout.
-	ChainURL         string        // URL of the blockchain node.
-	ChainID          int           // See session.chainconfig.
-	Adjudicator      string        // Address of the Adjudicator contract.
-	AssetETH         string        // Address of the ETH Asset holder contract.
-	ChainConnTimeout time.Duration // Timeout for connecting to blockchain node.
-	OnChainTxTimeout time.Duration // Timeout to wait for confirmation of on-chain tx.
-	ResponseTimeout  time.Duration // Timeout to wait for a response from the peer / user.
+	LogLevel         string            // LogLevel represents the log level for the node and all derived loggers.
+	LogFile          string            // LogFile represents the file to write logs. Empty string represents stdout.
+	ChainURL         string            // URL of the blockchain node.
+	ChainID          int               // See session.chainconfig.
+	Adjudicator      string            // Address of the Adjudicator contract.
+	AssetETH         string            // Address of the ETH Asset holder contract.
+	AssetERC20s      map[string]string // Address of ERC20 token contracts and corresponding asset contracts.
+	ChainConnTimeout time.Duration     // Timeout for connecting to blockchain node.
+	OnChainTxTimeout time.Duration     // Timeout to wait for confirmation of on-chain tx.
+	ResponseTimeout  time.Duration     // Timeout to wait for a response from the peer / user.
 
 	// Hard coded values. See cmd/perunnode/run.go.
 	CommTypes            []string // Communication protocols supported by the node for off-chain communication.

--- a/session/config_test.go
+++ b/session/config_test.go
@@ -24,7 +24,9 @@ import (
 	"gotest.tools/assert"
 
 	"github.com/hyperledger-labs/perun-node"
+	"github.com/hyperledger-labs/perun-node/blockchain/ethereum/ethereumtest"
 	"github.com/hyperledger-labs/perun-node/session"
+	"github.com/hyperledger-labs/perun-node/session/sessiontest"
 )
 
 var (
@@ -51,8 +53,14 @@ var (
 		},
 		IDProviderType: "local",
 		IDProviderURL:  "./test-idprovider.yaml",
-		ChainURL:       "ws://127.0.0.1:8545",
+		ChainURL:       ethereumtest.ChainURL,
+		ChainID:        ethereumtest.ChainID,
 		DatabaseDir:    "./test-db",
+
+		ChainConnTimeout:  ethereumtest.ChainConnTimeout,
+		OnChainTxTimeout:  ethereumtest.OnChainTxTimeout,
+		ResponseTimeout:   sessiontest.ResponseTimeout,
+		PeerReconnTimeout: sessiontest.PeerReconnTimeout,
 	}
 )
 

--- a/session/role_integ_test.go
+++ b/session/role_integ_test.go
@@ -40,7 +40,8 @@ import (
 // This test includes all methods on SessionAPI and ChAPI.
 func Test_Integ_Role(t *testing.T) {
 	// Deploy contracts.
-	ethereumtest.SetupContractsT(t, ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout)
+	contracts := ethereumtest.SetupContractsT(t,
+		ethereumtest.ChainURL, ethereumtest.ChainID, ethereumtest.OnChainTxTimeout, false)
 	currencies := currency.NewRegistry()
 	_, err := currencies.Register(currency.ETHSymbol, currency.ETHMaxDecimals)
 	require.NoError(t, err)
@@ -51,12 +52,12 @@ func Test_Integ_Role(t *testing.T) {
 	aliceCfg := sessiontest.NewConfigT(t, prng)
 	bobCfg := sessiontest.NewConfigT(t, prng)
 
-	alice, err := session.New(aliceCfg, currencies)
+	alice, err := session.New(aliceCfg, currencies, contracts)
 	require.NoErrorf(t, err, "initializing alice session")
 	t.Logf("alice session id: %s\n", alice.ID())
 	t.Logf("alice database dir is: %s\n", aliceCfg.DatabaseDir)
 
-	bob, err := session.New(bobCfg, currencies)
+	bob, err := session.New(bobCfg, currencies, contracts)
 	require.NoErrorf(t, err, "initializing bob session")
 	t.Logf("bob session id: %s\n", bob.ID())
 	t.Logf("bob database dir is: %s\n", bobCfg.DatabaseDir)

--- a/session/session.go
+++ b/session/session.go
@@ -156,7 +156,7 @@ func (r *chProposalResponderWrapped) Accept(ctx context.Context, proposalAcc *pc
 // New initializes a SessionAPI instance for the given configuration, read-only
 // currency registry and returns an instance of it. All methods on it are safe
 // for concurrent use.
-func New(cfg Config, currencies perun.ROCurrencyRegistry) (*Session, perun.APIError) {
+func New(cfg Config, currencies perun.ROCurrencyRegistry, contracts perun.ContractRegistry) (*Session, perun.APIError) {
 	user, apiErr := NewUnlockedUser(walletBackend, cfg.User)
 	if apiErr != nil {
 		return nil, apiErr
@@ -170,11 +170,11 @@ func New(cfg Config, currencies perun.ROCurrencyRegistry) (*Session, perun.APIEr
 	if apiErr != nil {
 		return nil, apiErr
 	}
-
+	assetETH := contracts.AssetETH()
 	chClientCfg := clientConfig{
 		Chain: ChainConfig{
-			Adjudicator:      cfg.Adjudicator,
-			AssetETH:         cfg.AssetETH,
+			Adjudicator:      contracts.Adjudicator(),
+			AssetETH:         assetETH,
 			URL:              cfg.ChainURL,
 			ChainID:          cfg.ChainID,
 			ConnTimeout:      cfg.ChainConnTimeout,

--- a/session/sessiontest/config.go
+++ b/session/sessiontest/config.go
@@ -108,7 +108,7 @@ func NewConfig(rng *rand.Rand, peerIDs ...perun.PeerID) (session.Config, error) 
 	if err != nil {
 		return session.Config{}, errors.WithMessage(err, "new user config")
 	}
-	adjudicator, assetETH := ethereumtest.ContractAddrs()
+	adjudicator, assetETH, _ := ethereumtest.ContractAddrs()
 	databaseDir, err := newDatabaseDir()
 	if err != nil {
 		return session.Config{}, err

--- a/testdata/node/valid.yaml
+++ b/testdata/node/valid.yaml
@@ -1,8 +1,11 @@
 loglevel: debug
 logfile: Node.log
 chainurl: ws://127.0.0.1:8545
+chainid: 1337
 adjudicator: 0x9daEdAcb21dce86Af8604Ba1A1D7F9BFE55ddd63
 assetETH: 0x5992089d61cE79B6CF90506F70DD42B8E42FB21d
+asseterc20s:
+    0x44cb7cd4C2B6435dA126F4263AafC3b837f49AbB: 0xb79708b3f6a4Be039BDE75281656c099163e7a5d
 chainconntimeout: 10s          
 onchaintxtimeout: 10s
 responsetimeout: 30s     

--- a/testdata/session/valid.yaml
+++ b/testdata/session/valid.yaml
@@ -10,10 +10,12 @@ user:
     password: test-password-off-chain
   commAddr: 127.0.0.1:5751
   commType: tcp
-
-
 idProviderType: local
 idProviderURL: ./test-idprovider.yaml
 chainURL: ws://127.0.0.1:8545  
-    
+chainid: 1337
+chainconntimeout: 10s
+onchaintxtimeout: 1m0s
+responsetimeout: 10s
 databaseDir: ./test-db 
+peerreconntimeout: 20s


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->

- Contract registry is implemented to keep track of adjudicator and
  asset ETH and asset ERC20 contracts.

- This is initialized by the node and it is passed onto each of the
  sessions with a read-only access.

- In upcoming changes, APIs will be added in node to add new ERC20 asset
  contracts to the contract registry.

Also,

- Update SetupContracts test helper function to setup ERC20 assets and
  return a contract registry instead of contract addresses.

- Update the reference templates for node & session config.

##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

<!-- Bug Fix -->
<!-- Improvement -->
Implementation Task

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

Resolves #193.

#### Testing
<!-- Tell us how you have tested the changes. -->

Tests have been updated to cover the new functionality. 

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

1. 
2. 
3.  

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
