### PR TITLE
Use weak scrypt N, P parameters everywhere

### DIFF
--- a/blockchain/ethereum/wallet.go
+++ b/blockchain/ethereum/wallet.go
@@ -27,7 +27,7 @@ import (
 // This enables the function to be loaded as symbol without importing this package when it is compiled as plugin.
 func NewWalletBackend() perun.WalletBackend {
 	return &internal.WalletBackend{EncParams: internal.ScryptParams{
-		N: internal.StandardScryptN,
-		P: internal.StandardScryptP,
+		N: internal.WeakScryptN,
+		P: internal.WeakScryptP,
 	}}
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->

- Currently weak scrypt parameters are used in tests within session
  package and for generating test data, while standard scrypt parameters
  are used everywhere else (integration tests in other packages, CLI &
  TUI apps).

- This causes the open session action in these tests and apps to be
  slower. Since, we use perun-node only in test environments with no
  real funds, use weak scrypt parameters everywhere to make the test and
  apps faster.


##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

<!-- Bug Fix -->
Improvement
<!-- Implementation Task -->

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

Resolves #216.

#### Testing
<!-- Tell us how you have tested the changes. -->

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

1. 
2. 
3.  

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [x] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.
