### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,11 +9,17 @@ single approval from a non-author maintainer for pull requests to be merged.
 
 | Name             | GitHub                                          | [Chat][_chat-url] |
 | ---------------- | ----------------------------------------------- | ----------------- |
-| Anagha Sukumaran | [anagha-ks](https://github.com/anagha-ks)       | anagha-ks         |
 | Chris Hoeppler   | [choeppler](https://github.com/choeppler)       | choeppler         |
 | Daniel Kunz      | [danielksan81](https://github.com/danielksan81) | danielksan81      |
 | Manoranjith      | [manoranjith](https://github.com/manoranjith)   | mano-ranjith      |
-| &nbsp;           |                                                 |                   |
+
+## Emeritus Maintainers
+
+<!-- Please keep this sorted alphabetically by github -->
+
+| Name             | GitHub                                          | [Chat][_chat-url] |
+| ---------------- | ----------------------------------------------- | ----------------- |
+| Anagha Sukumaran | [anagha-ks](https://github.com/anagha-ks)       | anagha-ks         |
 
 [_chat-url]: https://chat.hyperledger.org/channel/perun
 


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

https://github.com/hyperledger/toc/issues/32

Signed-off-by: Ry Jones <ry@linux.com>

<!-- Provide a general summary of your changes in the title above

Please read our contribution guidelines and sign the Contributor License
Agreement (CLA) before submitting the pull request. Also, check if there are no
other open pull requests targeting the same issue. -->

#### Description
<!-- Describe your changes in detail. -->

##### Category
<!-- Tell us what type of issue does your pull request target.
You can uncomment one of the following options: -->

<!-- Bug Fix -->
<!-- Improvement -->
<!-- Implementation Task -->

##### Relevant issue
<!-- Provide a link to the related issue. You can use the following keywords
and the issue number: "fixes", "resolves", "relates to". E.g.: closes #21

We accept only pull requests related to open issues. If you're suggesting a new
feature, improvement or fixing a bug that is not yet reported, please discuss it in
an issue before submitting a pull request. -->

#### Testing
<!-- Tell us how you have tested the changes. -->

##### Steps to run the tests
<!-- Describe a set of steps to run the tests relevant to this change. -->

1. 
2. 
3.  

#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [ ] Name is added to the NOTICE file, if it is not present already.
- [ ] Changes are rebased onto the target branch.
