### PR TITLE
docs: Correct link to perunnodeui README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For a tutorial on using perun-node with `perunnodecli`, see the
 on the project documentation website.
 
 For a tutorial on using perun-node with `perunnodetui`, see
-[this section](cmd/perunnodetui/Readme.md). A talk on overview of perun,
+[this section](cmd/perunnodetui/README.md). A talk on overview of perun,
 including a hands-on demo of using the perunnode with `perunnodetui` can be
 found [here](https://youtu.be/sASYSJm3QKw?t=916).
 


### PR DESCRIPTION
Small fix in the main readme, the link to the tutorial doesn't work unless the file name is all caps. 

##### Category
Docs 

#### Testing
<!-- Tell us how you have tested the changes. -->

Clicking on the link in my branch loads the tutorial. 


#### Checklist 
<!-- Please check if the pull request fulfils these requirements: -->

- [ ] Name is added to the NOTICE file, if it is not present already.
- [x] Changes are rebased onto the target branch.


I don't feel like my name needs to be added to the NOTICE file, if this is inappropriate feel free to close the PR and make the change yourself. 

Thank you! 